### PR TITLE
Feat/renewal use of a0 ar

### DIFF
--- a/src/relife/lifetime_model/_conditional_model.py
+++ b/src/relife/lifetime_model/_conditional_model.py
@@ -415,7 +415,7 @@ class LeftTruncatedModel(ParametricLifetimeModel[*tuple[AnyFloat, *Ts]]):
         return FrozenParametricLifetimeModel(self, a0, *args)
 
 
-def build_conditional_lifetime_model(lifetime_model: AnyParametricLifetimeModel[*Ts], a0: NumpyFloat | None = None, ar: NumpyFloat | None = None) -> AnyParametricLifetimeModel[*Ts]:
+def get_conditional_lifetime_model(lifetime_model: AnyParametricLifetimeModel[*Ts], a0: NumpyFloat | None = None, ar: NumpyFloat | None = None) -> AnyParametricLifetimeModel[*Ts]:
     # TODO: use copy method of parametricmodel
     applied_model = deepcopy(lifetime_model)
     if ar is not None:

--- a/src/relife/lifetime_model/_conditional_model.py
+++ b/src/relife/lifetime_model/_conditional_model.py
@@ -280,7 +280,7 @@ class LeftTruncatedModel(ParametricLifetimeModel[*tuple[AnyFloat, *Ts]]):
     @document_args(base_cls=ParametricLifetimeModel, args_docstring=_a0_args_docstring)
     def sf(self, time: AnyFloat, a0: AnyFloat, *args: *Ts) -> NumpyFloat:
         a0 = reshape_1d_arg(a0)
-        return self.baseline.sf(time + a0) / self.baseline.sf(a0) 
+        return self.baseline.sf(time + a0) / self.baseline.sf(a0)
 
     @override
     @document_args(base_cls=ParametricLifetimeModel, args_docstring=_a0_args_docstring)
@@ -415,15 +415,35 @@ class LeftTruncatedModel(ParametricLifetimeModel[*tuple[AnyFloat, *Ts]]):
         return FrozenParametricLifetimeModel(self, a0, *args)
 
 
-def get_conditional_lifetime_model(lifetime_model: FrozenParametricLifetimeModel, a0: NumpyFloat | None = None, ar: NumpyFloat | None = None) -> FrozenParametricLifetimeModel:
-    # TODO: use copy method of parametricmodel
+def get_conditional_lifetime_model(
+    lifetime_model: FrozenParametricLifetimeModel,
+    a0: NumpyFloat | None = None,
+    ar: NumpyFloat | None = None,
+) -> FrozenParametricLifetimeModel:
+    """
+        Fabric for conditional models
+
+        Parameters
+        ----------
+        a0 : float or np.ndarray or None
+            Initial ages
+        ar : float or np.ndarray or None
+            Preventive ages of replacements
+            
+        Returns
+        -------
+        FrozenParametricLifetimeModel
+    """
     applied_model = deepcopy(lifetime_model)
+
+    # Apply left truncation first for numerical stability
     if a0 is not None:
         applied_model = LeftTruncatedModel(applied_model).freeze(a0)
     if ar is not None:
         if a0 is not None:
-            applied_model = AgeReplacementModel(applied_model).freeze(ar-a0)
+            # If both are applied, ar becomes ar - a0
+            applied_model = AgeReplacementModel(applied_model).freeze(ar - a0)
         else:
             applied_model = AgeReplacementModel(applied_model).freeze(ar)
-    
+
     return applied_model

--- a/src/relife/lifetime_model/_conditional_model.py
+++ b/src/relife/lifetime_model/_conditional_model.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Callable
+from copy import deepcopy
 from typing import TypeVarTuple
 
 import numpy as np
@@ -412,3 +413,13 @@ class LeftTruncatedModel(ParametricLifetimeModel[*tuple[AnyFloat, *Ts]]):
         FrozenLeftTruncatedModel
         """
         return FrozenParametricLifetimeModel(self, a0, *args)
+
+
+def build_conditional_lifetime_model(lifetime_model: AnyParametricLifetimeModel[*Ts], a0: NumpyFloat | None = None, ar: NumpyFloat | None = None) -> AnyParametricLifetimeModel[*Ts]:
+    # TODO: use copy method of parametricmodel
+    applied_model = deepcopy(lifetime_model)
+    if ar is not None:
+        applied_model = AgeReplacementModel(applied_model).freeze(ar)
+    if a0 is not None:
+        applied_model = LeftTruncatedModel(applied_model).freeze(a0)
+    return applied_model

--- a/src/relife/lifetime_model/_conditional_model.py
+++ b/src/relife/lifetime_model/_conditional_model.py
@@ -418,8 +418,12 @@ class LeftTruncatedModel(ParametricLifetimeModel[*tuple[AnyFloat, *Ts]]):
 def get_conditional_lifetime_model(lifetime_model: FrozenParametricLifetimeModel, a0: NumpyFloat | None = None, ar: NumpyFloat | None = None) -> FrozenParametricLifetimeModel:
     # TODO: use copy method of parametricmodel
     applied_model = deepcopy(lifetime_model)
-    if ar is not None:
-        applied_model = AgeReplacementModel(applied_model).freeze(ar)
     if a0 is not None:
         applied_model = LeftTruncatedModel(applied_model).freeze(a0)
+    if ar is not None:
+        if a0 is not None:
+            applied_model = AgeReplacementModel(applied_model).freeze(ar-a0)
+        else:
+            applied_model = AgeReplacementModel(applied_model).freeze(ar)
+    
     return applied_model

--- a/src/relife/lifetime_model/_conditional_model.py
+++ b/src/relife/lifetime_model/_conditional_model.py
@@ -415,7 +415,7 @@ class LeftTruncatedModel(ParametricLifetimeModel[*tuple[AnyFloat, *Ts]]):
         return FrozenParametricLifetimeModel(self, a0, *args)
 
 
-def get_conditional_lifetime_model(lifetime_model: AnyParametricLifetimeModel[*Ts], a0: NumpyFloat | None = None, ar: NumpyFloat | None = None) -> AnyParametricLifetimeModel[*Ts]:
+def get_conditional_lifetime_model(lifetime_model: FrozenParametricLifetimeModel, a0: NumpyFloat | None = None, ar: NumpyFloat | None = None) -> FrozenParametricLifetimeModel:
     # TODO: use copy method of parametricmodel
     applied_model = deepcopy(lifetime_model)
     if ar is not None:

--- a/src/relife/lifetime_model/_conditional_model.py
+++ b/src/relife/lifetime_model/_conditional_model.py
@@ -280,7 +280,7 @@ class LeftTruncatedModel(ParametricLifetimeModel[*tuple[AnyFloat, *Ts]]):
     @document_args(base_cls=ParametricLifetimeModel, args_docstring=_a0_args_docstring)
     def sf(self, time: AnyFloat, a0: AnyFloat, *args: *Ts) -> NumpyFloat:
         a0 = reshape_1d_arg(a0)
-        return super().sf(time, a0, *args)
+        return self.baseline.sf(time + a0) / self.baseline.sf(a0) 
 
     @override
     @document_args(base_cls=ParametricLifetimeModel, args_docstring=_a0_args_docstring)

--- a/src/relife/policy/_base.py
+++ b/src/relife/policy/_base.py
@@ -11,14 +11,10 @@ from relife.typing import (
     AnyParametricLifetimeModel,
     NumpyFloat,
 )
+from relife.utils._array_utils import make_timeline
 from relife.utils.observation_bias import apply_bias, with_reshape_a0_ar
 
 __all__ = ["OneCycleExpectedCosts", "ReplacementPolicy"]
-
-
-def _make_timeline(tf: float, nb_steps: int) -> NDArray[np.float64]:
-    timeline = np.linspace(0, tf, nb_steps, dtype=np.float64)  # (nb_steps,)
-    return np.atleast_2d(timeline)  # (1, nb_steps) to ensure broadcasting
 
 
 class ExpectedCostsABC(ABC):
@@ -191,7 +187,7 @@ class OneCycleExpectedCosts(ExpectedCostsABC):
         ar: NumpyFloat | None = None,
         a0: NumpyFloat | None = None,
     ) -> tuple[NDArray[np.float64], NDArray[np.float64]]:
-        timeline = _make_timeline(tf, nb_steps)
+        timeline = make_timeline(tf, nb_steps)
         etc = np.asarray(
             get_conditional_lifetime_model(
                 self.lifetime_model, a0=a0, ar=ar
@@ -307,7 +303,7 @@ class OneCycleExpectedCosts(ExpectedCostsABC):
         ar: NumpyFloat | None = None,
         a0: NumpyFloat | None = None,
     ) -> tuple[NDArray[np.float64], NDArray[np.float64]]:
-        timeline = _make_timeline(tf, nb_steps)  # (nb_steps,) or (m, nb_steps)
+        timeline = make_timeline(tf, nb_steps)  # (nb_steps,) or (m, nb_steps)
         value = self._expected_equivalent_annual_cost(timeline, ar=ar, a0=a0)
         if timeline.ndim == 2:
             timeline = timeline[0, :]  # (nb_steps,)

--- a/src/relife/policy/_base.py
+++ b/src/relife/policy/_base.py
@@ -197,11 +197,7 @@ class OneCycleExpectedCosts(ExpectedCostsABC):
             ).ls_integrate(
                 lambda x: (
                     self.reward.conditional_expectation(apply_bias(x, delay=a0))
-                    * self.discounting.factor(
-                        apply_bias(
-                            x, delay=a0, censor_value=ar, delay_applied_to_censor=True
-                        )
-                    )
+                    * self.discounting.factor(x)
                 ),
                 np.zeros_like(timeline),
                 timeline,
@@ -249,11 +245,7 @@ class OneCycleExpectedCosts(ExpectedCostsABC):
             ).ls_integrate(
                 lambda x: (
                     self.reward.conditional_expectation(apply_bias(x, delay=a0))
-                    * self.discounting.factor(
-                        apply_bias(
-                            x, delay=a0, censor_value=ar, delay_applied_to_censor=True
-                        )
-                    )
+                    * self.discounting.factor(x)
                 ),
                 np.float64(0.0),
                 np.asarray(np.inf),
@@ -275,22 +267,13 @@ class OneCycleExpectedCosts(ExpectedCostsABC):
             # avoid zero division + 1e-6
             return (
                 self.reward.conditional_expectation(apply_bias(x, delay=a0))
-                * self.discounting.factor(
-                    apply_bias(
-                        x, delay=a0, censor_value=ar, delay_applied_to_censor=True
-                    )
-                )
-                / (
-                    self.discounting.annuity_factor(
-                        apply_bias(
-                            x, delay=a0, censor_value=ar, delay_applied_to_censor=True
-                        )
-                    )
-                    + 1e-6
-                )
+                * self.discounting.factor(x)
+                / (self.discounting.annuity_factor(x) + 1e-6)
             )
 
-        conditional_model = get_conditional_lifetime_model(self.lifetime_model, a0=a0)
+        conditional_model = get_conditional_lifetime_model(
+            self.lifetime_model, a0=a0, ar=ar
+        )
         q0 = conditional_model.cdf(self.period_before_discounting) * f(
             np.asarray(self.period_before_discounting, dtype=float)
         )  # () or (m, 1)
@@ -302,7 +285,7 @@ class OneCycleExpectedCosts(ExpectedCostsABC):
         a[timeline < self.period_before_discounting] = 0.0  # (nb_steps,)
         # a = np.where(timeline < self.period_before_discounting, 0., a)  # (nb_steps,)
         integral = conditional_model.ls_integrate(
-            f, a, timeline, deg=15
+            f, a, timeline, deg=20
         )  # (nb_steps,) or (m, nb_steps) if q0: (), or (m, nb_steps) if q0 : (m, 1)
         mask = np.broadcast_to(
             timeline < self.period_before_discounting, integral.shape

--- a/src/relife/policy/_base.py
+++ b/src/relife/policy/_base.py
@@ -6,10 +6,12 @@ import numpy as np
 from numpy.typing import NDArray
 
 from relife.economic import ExponentialDiscounting, Reward
+from relife.lifetime_model._conditional_model import get_conditional_lifetime_model
 from relife.typing import (
     AnyParametricLifetimeModel,
     NumpyFloat,
 )
+from relife.utils.observation_bias import apply_bias
 
 __all__ = ["OneCycleExpectedCosts", "ReplacementPolicy"]
 
@@ -181,13 +183,13 @@ class OneCycleExpectedCosts(ExpectedCostsABC):
         self.lifetime_model = lifetime_model
 
     def expected_net_present_value(
-        self, tf: float, nb_steps: int, total_sum: bool = False
+        self, tf: float, nb_steps: int, total_sum: bool = False, ar : NumpyFloat | None = None, a0 : NumpyFloat | None = None
     ) -> tuple[NDArray[np.float64], NDArray[np.float64]]:
         timeline = _make_timeline(tf, nb_steps)
         etc = np.asarray(
-            self.lifetime_model.ls_integrate(
-                lambda x: self.reward.conditional_expectation(x)
-                * self.discounting.factor(x),
+            get_conditional_lifetime_model(self.lifetime_model,a0=a0,ar=ar).ls_integrate(
+                lambda x: self.reward.conditional_expectation(apply_bias(x,delay=a0))
+                * self.discounting.factor(apply_bias(x,delay=a0,censor_value=ar,delay_applied_to_censor=True)),
                 np.zeros_like(timeline),
                 timeline,
                 deg=15,
@@ -202,24 +204,24 @@ class OneCycleExpectedCosts(ExpectedCostsABC):
 
     @overload
     def asymptotic_expected_net_present_value(
-        self, total_sum: Literal[False]
+        self, total_sum: Literal[False], ar : NumpyFloat | None = None, a0 : NumpyFloat | None = None
     ) -> NDArray[np.float64]: ...
     @overload
     def asymptotic_expected_net_present_value(
-        self, total_sum: Literal[True]
+        self, total_sum: Literal[True], ar : NumpyFloat | None = None, a0 : NumpyFloat | None = None
     ) -> np.float64: ...
     @overload
     def asymptotic_expected_net_present_value(
-        self, total_sum: bool = False
+        self, total_sum: bool = False, ar : NumpyFloat | None = None, a0 : NumpyFloat | None = None
     ) -> np.float64 | NDArray[np.float64]: ...
     def asymptotic_expected_net_present_value(
-        self, total_sum: bool = False
+        self, total_sum: bool = False, ar : NumpyFloat | None = None, a0 : NumpyFloat | None = None
     ) -> np.float64 | NDArray[np.float64]:
         # reward partial expectation
         value = np.squeeze(
-            self.lifetime_model.ls_integrate(
-                lambda x: self.reward.conditional_expectation(x)
-                * self.discounting.factor(x),
+            get_conditional_lifetime_model(self.lifetime_model,a0=a0,ar=ar).ls_integrate(
+                lambda x: self.reward.conditional_expectation(apply_bias(x,delay=a0))
+                * self.discounting.factor(apply_bias(x,delay=a0,censor_value=ar,delay_applied_to_censor=True)),
                 np.float64(0.0),
                 np.asarray(np.inf),
                 deg=15,
@@ -230,18 +232,18 @@ class OneCycleExpectedCosts(ExpectedCostsABC):
         return value  # () or (m,)
 
     def _expected_equivalent_annual_cost(
-        self, timeline: NDArray[np.float64]
+        self, timeline: NDArray[np.float64], ar : NumpyFloat | None = None, a0 : NumpyFloat | None = None
     ) -> NDArray[np.float64]:
         # timeline : (nb_steps,) or (m, nb_steps)
         def f(x: NDArray[np.float64]) -> NDArray[np.float64]:
             # avoid zero division + 1e-6
             return (
-                self.reward.conditional_expectation(x)
-                * self.discounting.factor(x)
-                / (self.discounting.annuity_factor(x) + 1e-6)
+                self.reward.conditional_expectation(apply_bias(x,delay=a0))
+                * self.discounting.factor(apply_bias(x,delay=a0,censor_value=ar,delay_applied_to_censor=True))
+                / (self.discounting.annuity_factor(apply_bias(x,delay=a0,censor_value=ar,delay_applied_to_censor=True)) + 1e-6)
             )
-
-        q0 = self.lifetime_model.cdf(self.period_before_discounting) * f(
+        conditional_model = get_conditional_lifetime_model(self.lifetime_model,a0=a0)
+        q0 = conditional_model.cdf(self.period_before_discounting) * f(
             np.asarray(self.period_before_discounting, dtype=float)
         )  # () or (m, 1)
         a = np.full_like(
@@ -251,7 +253,7 @@ class OneCycleExpectedCosts(ExpectedCostsABC):
         # change first value of lower bound to compute the integral
         a[timeline < self.period_before_discounting] = 0.0  # (nb_steps,)
         # a = np.where(timeline < self.period_before_discounting, 0., a)  # (nb_steps,)
-        integral = self.lifetime_model.ls_integrate(
+        integral = conditional_model.ls_integrate(
             f, a, timeline, deg=15
         )  # (nb_steps,) or (m, nb_steps) if q0: (), or (m, nb_steps) if q0 : (m, 1)
         mask = np.broadcast_to(
@@ -262,10 +264,10 @@ class OneCycleExpectedCosts(ExpectedCostsABC):
         return np.squeeze(integral)  # (nb_steps,)/(m, nb_steps)
 
     def expected_equivalent_annual_cost(
-        self, tf: float, nb_steps: int, total_sum: bool = False
+        self, tf: float, nb_steps: int, total_sum: bool = False, ar : NumpyFloat | None = None, a0 : NumpyFloat | None = None
     ) -> tuple[NDArray[np.float64], NDArray[np.float64]]:
         timeline = _make_timeline(tf, nb_steps)  # (nb_steps,) or (m, nb_steps)
-        value = self._expected_equivalent_annual_cost(timeline)
+        value = self._expected_equivalent_annual_cost(timeline,ar=ar,a0=a0)
         if timeline.ndim == 2:
             timeline = timeline[0, :]  # (nb_steps,)
         if total_sum and value.ndim == 2:
@@ -274,21 +276,21 @@ class OneCycleExpectedCosts(ExpectedCostsABC):
 
     @overload
     def asymptotic_expected_equivalent_annual_cost(
-        self, total_sum: Literal[False]
+        self, total_sum: Literal[False], ar : NumpyFloat | None = None, a0 : NumpyFloat | None = None
     ) -> NDArray[np.float64]: ...
     @overload
     def asymptotic_expected_equivalent_annual_cost(
-        self, total_sum: Literal[True]
+        self, total_sum: Literal[True], ar : NumpyFloat | None = None, a0 : NumpyFloat | None = None
     ) -> np.float64: ...
     @overload
     def asymptotic_expected_equivalent_annual_cost(
-        self, total_sum: bool = False
+        self, total_sum: bool = False, ar : NumpyFloat | None = None, a0 : NumpyFloat | None = None
     ) -> np.float64 | NDArray[np.float64]: ...
     def asymptotic_expected_equivalent_annual_cost(
-        self, total_sum: bool = False
+        self, total_sum: bool = False, ar : NumpyFloat | None = None, a0 : NumpyFloat | None = None
     ) -> np.float64 | NDArray[np.float64]:
         timeline = np.atleast_2d(np.array(np.inf))  # (1, 1) to ensure broadcasting
-        value = self._expected_equivalent_annual_cost(timeline)
+        value = self._expected_equivalent_annual_cost(timeline,ar=ar,a0=a0)
         if total_sum:
             value = np.sum(value)
         return value  # () or (m,)

--- a/src/relife/policy/_base.py
+++ b/src/relife/policy/_base.py
@@ -11,7 +11,7 @@ from relife.typing import (
     AnyParametricLifetimeModel,
     NumpyFloat,
 )
-from relife.utils.observation_bias import apply_bias
+from relife.utils.observation_bias import apply_bias, with_reshape_a0_ar
 
 __all__ = ["OneCycleExpectedCosts", "ReplacementPolicy"]
 
@@ -182,6 +182,7 @@ class OneCycleExpectedCosts(ExpectedCostsABC):
         self.period_before_discounting = period_before_discounting
         self.lifetime_model = lifetime_model
 
+    @with_reshape_a0_ar
     def expected_net_present_value(
         self,
         tf: float,
@@ -232,6 +233,8 @@ class OneCycleExpectedCosts(ExpectedCostsABC):
         ar: NumpyFloat | None = None,
         a0: NumpyFloat | None = None,
     ) -> np.float64 | NDArray[np.float64]: ...
+
+    @with_reshape_a0_ar
     def asymptotic_expected_net_present_value(
         self,
         total_sum: bool = False,
@@ -256,6 +259,7 @@ class OneCycleExpectedCosts(ExpectedCostsABC):
             value = np.sum(value)
         return value  # () or (m,)
 
+    @with_reshape_a0_ar
     def _expected_equivalent_annual_cost(
         self,
         timeline: NDArray[np.float64],
@@ -294,6 +298,7 @@ class OneCycleExpectedCosts(ExpectedCostsABC):
         integral = np.where(mask, q0, q0 + integral)
         return np.squeeze(integral)  # (nb_steps,)/(m, nb_steps)
 
+    @with_reshape_a0_ar
     def expected_equivalent_annual_cost(
         self,
         tf: float,
@@ -331,6 +336,8 @@ class OneCycleExpectedCosts(ExpectedCostsABC):
         ar: NumpyFloat | None = None,
         a0: NumpyFloat | None = None,
     ) -> np.float64 | NDArray[np.float64]: ...
+
+    @with_reshape_a0_ar
     def asymptotic_expected_equivalent_annual_cost(
         self,
         total_sum: bool = False,

--- a/src/relife/policy/_base.py
+++ b/src/relife/policy/_base.py
@@ -183,13 +183,26 @@ class OneCycleExpectedCosts(ExpectedCostsABC):
         self.lifetime_model = lifetime_model
 
     def expected_net_present_value(
-        self, tf: float, nb_steps: int, total_sum: bool = False, ar : NumpyFloat | None = None, a0 : NumpyFloat | None = None
+        self,
+        tf: float,
+        nb_steps: int,
+        total_sum: bool = False,
+        ar: NumpyFloat | None = None,
+        a0: NumpyFloat | None = None,
     ) -> tuple[NDArray[np.float64], NDArray[np.float64]]:
         timeline = _make_timeline(tf, nb_steps)
         etc = np.asarray(
-            get_conditional_lifetime_model(self.lifetime_model,a0=a0,ar=ar).ls_integrate(
-                lambda x: self.reward.conditional_expectation(apply_bias(x,delay=a0))
-                * self.discounting.factor(apply_bias(x,delay=a0,censor_value=ar,delay_applied_to_censor=True)),
+            get_conditional_lifetime_model(
+                self.lifetime_model, a0=a0, ar=ar
+            ).ls_integrate(
+                lambda x: (
+                    self.reward.conditional_expectation(apply_bias(x, delay=a0))
+                    * self.discounting.factor(
+                        apply_bias(
+                            x, delay=a0, censor_value=ar, delay_applied_to_censor=True
+                        )
+                    )
+                ),
                 np.zeros_like(timeline),
                 timeline,
                 deg=15,
@@ -204,24 +217,44 @@ class OneCycleExpectedCosts(ExpectedCostsABC):
 
     @overload
     def asymptotic_expected_net_present_value(
-        self, total_sum: Literal[False], ar : NumpyFloat | None = None, a0 : NumpyFloat | None = None
+        self,
+        total_sum: Literal[False],
+        ar: NumpyFloat | None = None,
+        a0: NumpyFloat | None = None,
     ) -> NDArray[np.float64]: ...
     @overload
     def asymptotic_expected_net_present_value(
-        self, total_sum: Literal[True], ar : NumpyFloat | None = None, a0 : NumpyFloat | None = None
+        self,
+        total_sum: Literal[True],
+        ar: NumpyFloat | None = None,
+        a0: NumpyFloat | None = None,
     ) -> np.float64: ...
     @overload
     def asymptotic_expected_net_present_value(
-        self, total_sum: bool = False, ar : NumpyFloat | None = None, a0 : NumpyFloat | None = None
+        self,
+        total_sum: bool = False,
+        ar: NumpyFloat | None = None,
+        a0: NumpyFloat | None = None,
     ) -> np.float64 | NDArray[np.float64]: ...
     def asymptotic_expected_net_present_value(
-        self, total_sum: bool = False, ar : NumpyFloat | None = None, a0 : NumpyFloat | None = None
+        self,
+        total_sum: bool = False,
+        ar: NumpyFloat | None = None,
+        a0: NumpyFloat | None = None,
     ) -> np.float64 | NDArray[np.float64]:
         # reward partial expectation
         value = np.squeeze(
-            get_conditional_lifetime_model(self.lifetime_model,a0=a0,ar=ar).ls_integrate(
-                lambda x: self.reward.conditional_expectation(apply_bias(x,delay=a0))
-                * self.discounting.factor(apply_bias(x,delay=a0,censor_value=ar,delay_applied_to_censor=True)),
+            get_conditional_lifetime_model(
+                self.lifetime_model, a0=a0, ar=ar
+            ).ls_integrate(
+                lambda x: (
+                    self.reward.conditional_expectation(apply_bias(x, delay=a0))
+                    * self.discounting.factor(
+                        apply_bias(
+                            x, delay=a0, censor_value=ar, delay_applied_to_censor=True
+                        )
+                    )
+                ),
                 np.float64(0.0),
                 np.asarray(np.inf),
                 deg=15,
@@ -232,17 +265,32 @@ class OneCycleExpectedCosts(ExpectedCostsABC):
         return value  # () or (m,)
 
     def _expected_equivalent_annual_cost(
-        self, timeline: NDArray[np.float64], ar : NumpyFloat | None = None, a0 : NumpyFloat | None = None
+        self,
+        timeline: NDArray[np.float64],
+        ar: NumpyFloat | None = None,
+        a0: NumpyFloat | None = None,
     ) -> NDArray[np.float64]:
         # timeline : (nb_steps,) or (m, nb_steps)
         def f(x: NDArray[np.float64]) -> NDArray[np.float64]:
             # avoid zero division + 1e-6
             return (
-                self.reward.conditional_expectation(apply_bias(x,delay=a0))
-                * self.discounting.factor(apply_bias(x,delay=a0,censor_value=ar,delay_applied_to_censor=True))
-                / (self.discounting.annuity_factor(apply_bias(x,delay=a0,censor_value=ar,delay_applied_to_censor=True)) + 1e-6)
+                self.reward.conditional_expectation(apply_bias(x, delay=a0))
+                * self.discounting.factor(
+                    apply_bias(
+                        x, delay=a0, censor_value=ar, delay_applied_to_censor=True
+                    )
+                )
+                / (
+                    self.discounting.annuity_factor(
+                        apply_bias(
+                            x, delay=a0, censor_value=ar, delay_applied_to_censor=True
+                        )
+                    )
+                    + 1e-6
+                )
             )
-        conditional_model = get_conditional_lifetime_model(self.lifetime_model,a0=a0)
+
+        conditional_model = get_conditional_lifetime_model(self.lifetime_model, a0=a0)
         q0 = conditional_model.cdf(self.period_before_discounting) * f(
             np.asarray(self.period_before_discounting, dtype=float)
         )  # () or (m, 1)
@@ -264,10 +312,15 @@ class OneCycleExpectedCosts(ExpectedCostsABC):
         return np.squeeze(integral)  # (nb_steps,)/(m, nb_steps)
 
     def expected_equivalent_annual_cost(
-        self, tf: float, nb_steps: int, total_sum: bool = False, ar : NumpyFloat | None = None, a0 : NumpyFloat | None = None
+        self,
+        tf: float,
+        nb_steps: int,
+        total_sum: bool = False,
+        ar: NumpyFloat | None = None,
+        a0: NumpyFloat | None = None,
     ) -> tuple[NDArray[np.float64], NDArray[np.float64]]:
         timeline = _make_timeline(tf, nb_steps)  # (nb_steps,) or (m, nb_steps)
-        value = self._expected_equivalent_annual_cost(timeline,ar=ar,a0=a0)
+        value = self._expected_equivalent_annual_cost(timeline, ar=ar, a0=a0)
         if timeline.ndim == 2:
             timeline = timeline[0, :]  # (nb_steps,)
         if total_sum and value.ndim == 2:
@@ -276,21 +329,33 @@ class OneCycleExpectedCosts(ExpectedCostsABC):
 
     @overload
     def asymptotic_expected_equivalent_annual_cost(
-        self, total_sum: Literal[False], ar : NumpyFloat | None = None, a0 : NumpyFloat | None = None
+        self,
+        total_sum: Literal[False],
+        ar: NumpyFloat | None = None,
+        a0: NumpyFloat | None = None,
     ) -> NDArray[np.float64]: ...
     @overload
     def asymptotic_expected_equivalent_annual_cost(
-        self, total_sum: Literal[True], ar : NumpyFloat | None = None, a0 : NumpyFloat | None = None
+        self,
+        total_sum: Literal[True],
+        ar: NumpyFloat | None = None,
+        a0: NumpyFloat | None = None,
     ) -> np.float64: ...
     @overload
     def asymptotic_expected_equivalent_annual_cost(
-        self, total_sum: bool = False, ar : NumpyFloat | None = None, a0 : NumpyFloat | None = None
+        self,
+        total_sum: bool = False,
+        ar: NumpyFloat | None = None,
+        a0: NumpyFloat | None = None,
     ) -> np.float64 | NDArray[np.float64]: ...
     def asymptotic_expected_equivalent_annual_cost(
-        self, total_sum: bool = False, ar : NumpyFloat | None = None, a0 : NumpyFloat | None = None
+        self,
+        total_sum: bool = False,
+        ar: NumpyFloat | None = None,
+        a0: NumpyFloat | None = None,
     ) -> np.float64 | NDArray[np.float64]:
         timeline = np.atleast_2d(np.array(np.inf))  # (1, 1) to ensure broadcasting
-        value = self._expected_equivalent_annual_cost(timeline,ar=ar,a0=a0)
+        value = self._expected_equivalent_annual_cost(timeline, ar=ar, a0=a0)
         if total_sum:
             value = np.sum(value)
         return value  # () or (m,)

--- a/src/relife/policy/_preventive_age_replacement.py
+++ b/src/relife/policy/_preventive_age_replacement.py
@@ -26,6 +26,7 @@ from relife.utils import (
     flatten_if_possible,
     reshape_1d_arg,
 )
+from relife.utils.observation_bias import with_reshape_a0_ar
 from relife.utils.quadrature import legendre_quadrature
 
 from ._base import OneCycleExpectedCosts, ReplacementPolicy
@@ -265,6 +266,7 @@ class OneCycleAgeReplacementPolicy(BaseAgeReplacementPolicy):
         )
 
     @check_impossible_replacements
+    @with_reshape_a0_ar
     def expected_net_present_value(
         self,
         ar: NumpyFloat,
@@ -299,6 +301,7 @@ class OneCycleAgeReplacementPolicy(BaseAgeReplacementPolicy):
         )  # () or (m, nb_steps)
 
     @check_impossible_replacements
+    @with_reshape_a0_ar
     def expected_equivalent_annual_cost(
         self,
         ar: NumpyFloat,
@@ -330,6 +333,7 @@ class OneCycleAgeReplacementPolicy(BaseAgeReplacementPolicy):
     ) -> np.float64 | NDArray[np.float64]: ...
 
     @check_impossible_replacements
+    @with_reshape_a0_ar
     def asymptotic_expected_equivalent_annual_cost(
         self, ar: NumpyFloat, total_sum: bool = False, a0: NumpyFloat | None = None
     ) -> np.float64 | NDArray[np.float64]:
@@ -415,6 +419,7 @@ class AgeReplacementPolicy(BaseAgeReplacementPolicy):
         )
 
     @check_impossible_replacements
+    @with_reshape_a0_ar
     def expected_net_present_value(
         self,
         ar: NumpyFloat,
@@ -444,6 +449,7 @@ class AgeReplacementPolicy(BaseAgeReplacementPolicy):
     ) -> np.float64 | NDArray[np.float64]: ...
 
     @check_impossible_replacements
+    @with_reshape_a0_ar
     def asymptotic_expected_net_present_value(
         self, ar: NumpyFloat, total_sum: bool = False, a0: NumpyFloat | None = None
     ) -> np.float64 | NDArray[np.float64]:
@@ -455,6 +461,7 @@ class AgeReplacementPolicy(BaseAgeReplacementPolicy):
         return asymptotic_npv
 
     @check_impossible_replacements
+    @with_reshape_a0_ar
     def expected_equivalent_annual_cost(
         self,
         ar: NumpyFloat,
@@ -485,6 +492,7 @@ class AgeReplacementPolicy(BaseAgeReplacementPolicy):
     ) -> np.float64 | NDArray[np.float64]: ...
 
     @check_impossible_replacements
+    @with_reshape_a0_ar
     def asymptotic_expected_equivalent_annual_cost(
         self, ar: NumpyFloat, total_sum: bool = False, a0: NumpyFloat | None = None
     ) -> np.float64 | NDArray[np.float64]:
@@ -497,6 +505,7 @@ class AgeReplacementPolicy(BaseAgeReplacementPolicy):
         return asymptotic_eeac  # () or (m,)
 
     @check_impossible_replacements
+    @with_reshape_a0_ar
     def annual_number_of_replacements(
         self,
         ar: NumpyFloat,
@@ -584,6 +593,7 @@ class AgeReplacementPolicy(BaseAgeReplacementPolicy):
         return newton(eq, x0)  # pyright: ignore
 
     @check_impossible_replacements
+    @with_reshape_a0_ar
     def generate_failure_data(
         self,
         ar: NumpyFloat,
@@ -615,6 +625,7 @@ class AgeReplacementPolicy(BaseAgeReplacementPolicy):
         )
 
     @check_impossible_replacements
+    @with_reshape_a0_ar
     def sample(
         self,
         ar: NumpyFloat,
@@ -702,6 +713,7 @@ class NonHomogeneousPoissonAgeReplacementPolicy(ReplacementPolicy):
     def cr(self, value):
         self._cost_structure["cr"] = reshape_1d_arg(value)
 
+    @with_reshape_a0_ar
     def expected_net_present_value(
         self,
         tf,
@@ -712,11 +724,13 @@ class NonHomogeneousPoissonAgeReplacementPolicy(ReplacementPolicy):
     ):
         raise NotImplementedError("implementation will come in a future release")
 
+    @with_reshape_a0_ar
     def asymptotic_expected_net_present_value(
         self, ar: NumpyFloat, total_sum=False, a0: NumpyFloat | None = None
     ):
         raise NotImplementedError("implementation will come in a future release")
 
+    @with_reshape_a0_ar
     def expected_equivalent_annual_cost(
         self,
         ar: NumpyFloat,
@@ -727,6 +741,7 @@ class NonHomogeneousPoissonAgeReplacementPolicy(ReplacementPolicy):
     ):
         raise NotImplementedError("implementation will come in a future release")
 
+    @with_reshape_a0_ar
     def asymptotic_expected_equivalent_annual_cost(
         self, ar: NumpyFloat, a0: NumpyFloat | None = None
     ):
@@ -756,7 +771,7 @@ class NonHomogeneousPoissonAgeReplacementPolicy(ReplacementPolicy):
             )
         return np.squeeze(asymptotic_eeac)  # () or (m,)
 
-    def optimize(self):
+    def compute_optimal_ar(self) -> NumpyFloat:
         """
         Optimize the policy according the costs, the discounting rate and the underlying non-homogeneous Poisson process.
 
@@ -790,5 +805,4 @@ class NonHomogeneousPoissonAgeReplacementPolicy(ReplacementPolicy):
                 - self._cost_structure["cp"] / self._cost_structure["cr"]
             )
 
-        self.ar = newton(eq, x0)
-        return self
+        return newton(eq, x0)

--- a/src/relife/policy/_preventive_age_replacement.py
+++ b/src/relife/policy/_preventive_age_replacement.py
@@ -40,35 +40,29 @@ __all__ = [
 ]
 
 
-# def requires_ar(method):
-#     @functools.wraps(method)
-#     def wrapper(self, *args, **kwargs):
-#         if not hasattr(self, 'ar') or self.ar is None:
-#             raise ValueError(
-#                 f"Age replacements must be set or optimised before using '{method.__name__}'"
-#             )
-#         return method(self, *args, **kwargs)
-#     return wrapper
+def check_impossible_replacements(func):
+    @functools.wraps(func)
+    def wrapper(*args, **kwargs):
+        # Get ar and a0
+        import inspect
+        sig = inspect.signature(func)
+        bound = sig.bind(*args, **kwargs)
+        bound.apply_defaults()
+        params = bound.arguments
 
+        ar = params.get("ar")
+        a0 = params.get("a0", None)
 
-# def requires_valid_periods(method):
-#     @functools.wraps(method)
-#     def wrapper(self, *args, **kwargs):
-#         if np.any(self.period_before_discounting >= self.ar):
-#             raise ValueError(
-#                 "The period before discounting must be lower than age replacement values"
-#             )
-#         if np.any(self.tr1 == 0):
-#             warnings.warn(
-#                 "Some assets has already been replaced for the first cycle (ar < a0). For these assets, consider manually adjusting age of replacements."
-#             )
-#             ar = self.ar.copy()
-#             self.ar = np.where(self.tr1 == 0, np.inf, self.ar)
-#             result = method(self, *args, **kwargs)
-#             self.ar = ar
-#             return result
-#         return method(self, *args, **kwargs)
-#     return wrapper
+        # check ar is greater than a0 if a0 is provided
+        if a0 is not None:
+            if not (np.atleast_1d(ar) >= np.atleast_1d(a0)).all():
+                raise ValueError(
+                    f"Some assets are using an optimal age of replacement inferior to their current age. Please consider changing the age of replacement."
+                )
+
+        return func(*args, **kwargs)
+    return wrapper
+
 
 
 @overload
@@ -277,7 +271,7 @@ class OneCycleAgeReplacementPolicy(BaseAgeReplacementPolicy):
             period_before_discounting=self.period_before_discounting
         )
 
-
+    @check_impossible_replacements
     def expected_net_present_value(
         self, ar : NumpyFloat, tf: float, nb_steps: int, total_sum: bool = False, a0 : NumpyFloat | None = None
     ) -> tuple[NDArray[np.float64], NDArray[np.float64]]:
@@ -297,6 +291,8 @@ class OneCycleAgeReplacementPolicy(BaseAgeReplacementPolicy):
     def asymptotic_expected_net_present_value(
         self, ar : NumpyFloat, total_sum: bool = False, a0 : NumpyFloat | None = None
     ) -> np.float64 | NDArray[np.float64]: ...
+
+    @check_impossible_replacements
     def asymptotic_expected_net_present_value(
         self, ar : NumpyFloat, total_sum: bool = False, a0 : NumpyFloat | None = None
     ) -> np.float64 | NDArray[np.float64]:
@@ -304,7 +300,7 @@ class OneCycleAgeReplacementPolicy(BaseAgeReplacementPolicy):
             self._expected_costs(ar=ar).asymptotic_expected_net_present_value(total_sum,ar=ar,a0=a0)
         )  # () or (m, nb_steps)
 
-
+    @check_impossible_replacements
     def expected_equivalent_annual_cost(
         self, ar : NumpyFloat, tf: float, nb_steps: int, total_sum: bool = False, a0 : NumpyFloat | None = None
     ) -> tuple[NDArray[np.float64], NDArray[np.float64]]:
@@ -329,6 +325,8 @@ class OneCycleAgeReplacementPolicy(BaseAgeReplacementPolicy):
     def asymptotic_expected_equivalent_annual_cost(
         self, ar : NumpyFloat, total_sum: bool = False, a0 : NumpyFloat | None = None
     ) -> np.float64 | NDArray[np.float64]: ...
+
+    @check_impossible_replacements
     def asymptotic_expected_equivalent_annual_cost(
         self, ar : NumpyFloat, total_sum: bool = False, a0 : NumpyFloat | None = None
     ) -> np.float64 | NDArray[np.float64]:
@@ -413,6 +411,7 @@ class AgeReplacementPolicy(BaseAgeReplacementPolicy):
                 discounting_rate=self.discounting_rate,
             )
 
+    @check_impossible_replacements
     def expected_net_present_value(
         self, ar : NumpyFloat, tf: float, nb_steps: int, total_sum: bool = False, a0 : NumpyFloat | None = None
     ) -> tuple[NDArray[np.float64], NDArray[np.float64]]:
@@ -433,6 +432,8 @@ class AgeReplacementPolicy(BaseAgeReplacementPolicy):
     def asymptotic_expected_net_present_value(
         self, ar : NumpyFloat, total_sum: bool = False, a0 : NumpyFloat | None = None
     ) -> np.float64 | NDArray[np.float64]: ...
+
+    @check_impossible_replacements
     def asymptotic_expected_net_present_value(
         self, ar : NumpyFloat, total_sum: bool = False, a0 : NumpyFloat | None = None
     ) -> np.float64 | NDArray[np.float64]:
@@ -443,6 +444,7 @@ class AgeReplacementPolicy(BaseAgeReplacementPolicy):
             asymptotic_npv = np.sum(asymptotic_npv)
         return asymptotic_npv
 
+    @check_impossible_replacements
     def expected_equivalent_annual_cost(
         self, ar : NumpyFloat, tf: float, nb_steps: int, total_sum: bool = False, a0 : NumpyFloat | None = None
     ) -> tuple[NDArray[np.float64], NDArray[np.float64]]:
@@ -467,6 +469,7 @@ class AgeReplacementPolicy(BaseAgeReplacementPolicy):
         self, ar : NumpyFloat, total_sum: bool = False, a0 : NumpyFloat | None = None
     ) -> np.float64 | NDArray[np.float64]: ...
 
+    @check_impossible_replacements
     def asymptotic_expected_equivalent_annual_cost(
         self, ar : NumpyFloat, total_sum: bool = False, a0 : NumpyFloat | None = None
     ) -> np.float64 | NDArray[np.float64]:
@@ -478,6 +481,7 @@ class AgeReplacementPolicy(BaseAgeReplacementPolicy):
             asymptotic_eeac = np.sum(asymptotic_eeac)
         return asymptotic_eeac  # () or (m,)
 
+    @check_impossible_replacements
     def annual_number_of_replacements(self, ar : NumpyFloat, nb_years : int, upon_failure=False, total=True, a0 : NumpyFloat | None = None):
         """
         The expected number of annual replacements.
@@ -554,6 +558,7 @@ class AgeReplacementPolicy(BaseAgeReplacementPolicy):
 
         return newton(eq, x0) # pyright: ignore
 
+    @check_impossible_replacements
     def generate_failure_data(
         self, ar : NumpyFloat, nb_samples: int, time_window: tuple[float, float], a0 : NumpyFloat | None = None, seed=None,
     ):
@@ -579,6 +584,7 @@ class AgeReplacementPolicy(BaseAgeReplacementPolicy):
             nb_samples, time_window, ar=ar, a0=a0, seed=seed
         )
 
+    @check_impossible_replacements
     def sample(self, ar : NumpyFloat, nb_samples: int, time_window: tuple[float, float], a0 : NumpyFloat | None = None, seed=None):
         """Renewal data sampling.
 

--- a/src/relife/policy/_preventive_age_replacement.py
+++ b/src/relife/policy/_preventive_age_replacement.py
@@ -223,18 +223,11 @@ class OneCycleAgeReplacementPolicy(BaseAgeReplacementPolicy):
         Costs of preventive replacements
     discounting_rate : float, default is 0.
         The discounting rate value used in the exponential discounting function
-    a0 : float or 1darray, optional
-        Current ages of the assets. If it is given, left truncations of ``a0`` will
-        be take into account for the first cycle.
-    ar : float or 1darray, optional
-        Ages of preventive replacements, by default None. If not given, one must call ``optimize`` to set ``ar`` values
-        and access to the rest of the object interface.
 
     Attributes
     ----------
     cf
     cp
-    ar
 
     References
     ----------
@@ -345,12 +338,12 @@ class OneCycleAgeReplacementPolicy(BaseAgeReplacementPolicy):
 
     def compute_optimal_ar(self) -> NumpyFloat:
         """
-        Optimize the policy according the costs, the discounting rate and the underlying lifetime model.
+        Optimize the policy according to the costs, the discounting rate and the underlying lifetime model.
 
         Returns
         -------
-        Self
-             Optimized policy.
+        ar : float or np.ndarray
+            Optimal ages of replacements.
         """
 
         discounting = ExponentialDiscounting(self.discounting_rate)
@@ -519,12 +512,16 @@ class AgeReplacementPolicy(BaseAgeReplacementPolicy):
 
         Parameters
         ----------
+        ar : float or np.ndarray
+            Ages of replacements
         nb_years : int
             The number of years on which the annual number of replacements are projected
         upon_failure : bool, default is False
             If True, it also returns the annual number of replacements due to unexpected failures
         total : bool, default is True
             If True, the given numbers of replacements are the sum of all replacements without distinction between assets
+        a0 : float or np.ndarray or None
+            Optional, initial ages
         """
 
         timeline, total_renewals = self._stochastic_reward_process(
@@ -549,13 +546,14 @@ class AgeReplacementPolicy(BaseAgeReplacementPolicy):
 
     def compute_optimal_ar(self) -> NumpyFloat:
         """
-        Optimize the policy according the costs, the discounting rate and the underlying lifetime model.
+        Optimize the policy according to the costs, the discounting rate and the underlying lifetime model.
 
         Returns
         -------
-        Self
-             Optimized policy.
+        ar : float or np.ndarray
+            Optimal ages of replacements.
         """
+
         discounting = ExponentialDiscounting(self.discounting_rate)
         x0 = np.minimum(
             self._cost_structure["cp"]
@@ -608,12 +606,16 @@ class AgeReplacementPolicy(BaseAgeReplacementPolicy):
 
         Parameters
         ----------
+        ar : float or np.ndarray
+            Ages of replacements
         nb_samples : int
             The number of samples.
         time_window : tuple of two floats
             Time window in which data are sampled.
         seed : int, optional
             Random seed, by default None.
+        a0 : float or np.ndarray or None
+            Optional, initial ages
 
         Returns
         -------
@@ -667,15 +669,11 @@ class NonHomogeneousPoissonAgeReplacementPolicy(ReplacementPolicy):
         The cost of failure.
     discounting_rate : float, default is 0.
         The discounting rate value used in the exponential discounting function
-    ar : float or 1darray, optional
-        Ages of preventive replacements, by default None. If not given, one must call ``optimize`` to set ``ar`` values
-        and access to the rest of the object interface.
 
     Attributes
     ----------
     cp
     cr
-    ar
     """
 
     def __init__(self, nhpp, cr, cp, discounting_rate=0.0):
@@ -746,7 +744,9 @@ class NonHomogeneousPoissonAgeReplacementPolicy(ReplacementPolicy):
         self, ar: NumpyFloat, a0: NumpyFloat | None = None
     ):
         if a0 is not None:
-            raise ValueError("NHPP policies with initial ages will be covered in a future release")
+            raise ValueError(
+                "NHPP policies with initial ages will be covered in a future release"
+            )
 
         discounting = ExponentialDiscounting(self.discounting_rate)
 
@@ -776,12 +776,12 @@ class NonHomogeneousPoissonAgeReplacementPolicy(ReplacementPolicy):
 
     def compute_optimal_ar(self) -> NumpyFloat:
         """
-        Optimize the policy according the costs, the discounting rate and the underlying non-homogeneous Poisson process.
+        Optimize the policy according to the costs, the discounting rate and the underlying lifetime model.
 
         Returns
         -------
-        Self
-             Optimized policy.
+        ar : float or np.ndarray
+            Optimal ages of replacements.
         """
 
         discounting = ExponentialDiscounting(self.discounting_rate)

--- a/src/relife/policy/_preventive_age_replacement.py
+++ b/src/relife/policy/_preventive_age_replacement.py
@@ -745,6 +745,9 @@ class NonHomogeneousPoissonAgeReplacementPolicy(ReplacementPolicy):
     def asymptotic_expected_equivalent_annual_cost(
         self, ar: NumpyFloat, a0: NumpyFloat | None = None
     ):
+        if a0 is not None:
+            raise ValueError("NHPP policies with initial ages will be covered in a future release")
+
         discounting = ExponentialDiscounting(self.discounting_rate)
 
         if self.discounting_rate == 0.0:

--- a/src/relife/policy/_preventive_age_replacement.py
+++ b/src/relife/policy/_preventive_age_replacement.py
@@ -15,6 +15,7 @@ from relife.lifetime_model import (
     AgeReplacementModel,
     LeftTruncatedModel,
 )
+from relife.lifetime_model._conditional_model import get_conditional_lifetime_model
 from relife.stochastic_process import RenewalRewardProcess
 from relife.stochastic_process.non_homogeneous_poisson_process import (
     FrozenNonHomogeneousPoissonProcess,
@@ -39,35 +40,35 @@ __all__ = [
 ]
 
 
-def requires_ar(method):
-    @functools.wraps(method)
-    def wrapper(self, *args, **kwargs):
-        if not hasattr(self, 'ar') or self.ar is None:
-            raise ValueError(
-                f"Age replacements must be set or optimised before using '{method.__name__}'"
-            )
-        return method(self, *args, **kwargs)
-    return wrapper
+# def requires_ar(method):
+#     @functools.wraps(method)
+#     def wrapper(self, *args, **kwargs):
+#         if not hasattr(self, 'ar') or self.ar is None:
+#             raise ValueError(
+#                 f"Age replacements must be set or optimised before using '{method.__name__}'"
+#             )
+#         return method(self, *args, **kwargs)
+#     return wrapper
 
 
-def requires_valid_periods(method):
-    @functools.wraps(method)
-    def wrapper(self, *args, **kwargs):
-        if np.any(self.period_before_discounting >= self.ar):
-            raise ValueError(
-                "The period before discounting must be lower than age replacement values"
-            )
-        if np.any(self.tr1 == 0):
-            warnings.warn(
-                "Some assets has already been replaced for the first cycle (ar < a0). For these assets, consider manually adjusting age of replacements."
-            )
-            ar = self.ar.copy()
-            self.ar = np.where(self.tr1 == 0, np.inf, self.ar)
-            result = method(self, *args, **kwargs)
-            self.ar = ar
-            return result
-        return method(self, *args, **kwargs)
-    return wrapper
+# def requires_valid_periods(method):
+#     @functools.wraps(method)
+#     def wrapper(self, *args, **kwargs):
+#         if np.any(self.period_before_discounting >= self.ar):
+#             raise ValueError(
+#                 "The period before discounting must be lower than age replacement values"
+#             )
+#         if np.any(self.tr1 == 0):
+#             warnings.warn(
+#                 "Some assets has already been replaced for the first cycle (ar < a0). For these assets, consider manually adjusting age of replacements."
+#             )
+#             ar = self.ar.copy()
+#             self.ar = np.where(self.tr1 == 0, np.inf, self.ar)
+#             result = method(self, *args, **kwargs)
+#             self.ar = ar
+#             return result
+#         return method(self, *args, **kwargs)
+#     return wrapper
 
 
 @overload
@@ -159,8 +160,6 @@ def age_replacement_policy(
 
 class BaseAgeReplacementPolicy(ReplacementPolicy[AnyParametricLifetimeModel[()]], ABC):
     _cost_structure: dict[str, NumpyFloat]
-    _ar: Optional[NumpyFloat]
-    _a0: Optional[NumpyFloat]
     discounting_rate: float
 
     def __init__(
@@ -169,29 +168,12 @@ class BaseAgeReplacementPolicy(ReplacementPolicy[AnyParametricLifetimeModel[()]]
         cf: AnyFloat,
         cp: AnyFloat,
         discounting_rate: float = 0.0,
-        a0: Optional[AnyFloat] = None,
-        ar: Optional[AnyFloat] = None,
     ):
         super().__init__(
             lifetime_model,
             {"cf": reshape_1d_arg(cf), "cp": reshape_1d_arg(cp)},
             discounting_rate=discounting_rate,
         )
-        self._a0 = reshape_1d_arg(a0) if a0 is not None else a0
-        self._ar = reshape_1d_arg(ar) if ar is not None else ar
-
-    @property
-    def a0(self) -> Optional[NumpyFloat]:
-        """Current ages of the assets.
-
-        Returns
-        -------
-        np.ndarray
-        """
-        # _a0 is (m, 1) but exposed cf is (m,)
-        if self._a0 is None:
-            return self._a0
-        return flatten_if_possible(self._a0)
 
     @property
     def cf(self) -> NumpyFloat:
@@ -223,38 +205,6 @@ class BaseAgeReplacementPolicy(ReplacementPolicy[AnyParametricLifetimeModel[()]]
     def cp(self, value: AnyFloat) -> None:
         self._cost_structure["cp"] = reshape_1d_arg(value)
 
-    @property
-    def ar(self) -> Optional[NumpyFloat]:
-        """Preventive ages of replacement.
-
-        Returns
-        -------
-        np.ndarray
-        """
-        # _ar is (m, 1) but exposed ar is (m,)
-        if self._ar is None:
-            return self._ar
-        return flatten_if_possible(self._ar)
-
-    @ar.setter
-    def ar(self, value: Optional[AnyFloat]) -> None:
-        if value is not None:
-            self._ar = reshape_1d_arg(value)
-        else:
-            self._ar = None
-
-    @property
-    def tr1(self) -> Optional[NumpyFloat]:
-        """Times before the first replacement.
-
-        Returns
-        -------
-        np.ndarray
-        """
-        if self._a0 is not None and self._ar is not None:
-            tr = np.maximum(self._ar - self._a0, 0)
-            return flatten_if_possible(tr)
-        return self.ar
 
 
 class OneCycleAgeReplacementPolicy(BaseAgeReplacementPolicy):
@@ -311,70 +261,57 @@ class OneCycleAgeReplacementPolicy(BaseAgeReplacementPolicy):
         cp: AnyFloat,
         discounting_rate: float = 0.0,
         period_before_discounting: float = 1.0,
-        a0: Optional[AnyFloat] = None,
-        ar: Optional[AnyFloat] = None,
     ):
         super().__init__(
-            lifetime_model, cf, cp, discounting_rate=discounting_rate, a0=a0, ar=ar
+            lifetime_model, cf, cp, discounting_rate=discounting_rate
         )
         self.period_before_discounting = period_before_discounting
 
-
-    @property
-    @requires_ar
-    def _expected_costs(self) -> OneCycleExpectedCosts:
-        conditional_model = get_conditional_lifetime_model(self.baseline_model,a0=self.a0)
+    def _expected_costs(self, ar : NumpyFloat) -> OneCycleExpectedCosts:
         return OneCycleExpectedCosts(
-            conditional_model,
+            self.baseline_model,
             AgeReplacementReward(
-                self.cf, self.cp, self.tr1
+                self.cf, self.cp, ar
             ),
             discounting_rate=self.discounting_rate,
             period_before_discounting=self.period_before_discounting
         )
 
-    @requires_ar
+
     def expected_net_present_value(
-        self, tf: float, nb_steps: int, total_sum: bool = False
+        self, ar : NumpyFloat, tf: float, nb_steps: int, total_sum: bool = False, a0 : NumpyFloat | None = None
     ) -> tuple[NDArray[np.float64], NDArray[np.float64]]:
-        return self._expected_costs.expected_net_present_value(
-            tf, nb_steps, total_sum=total_sum
+        return self._expected_costs(ar=ar).expected_net_present_value(
+            tf, nb_steps, total_sum=total_sum, ar=ar, a0=a0
         )  # (nb_steps,), (nb_steps,) or (nb_steps,), (m, nb_steps)
 
     @overload
     def asymptotic_expected_net_present_value(
-        self, total_sum: Literal[False]
+        self, ar : NumpyFloat, total_sum: Literal[False], a0 : NumpyFloat | None = None
     ) -> NDArray[np.float64]: ...
     @overload
     def asymptotic_expected_net_present_value(
-        self, total_sum: Literal[True]
+        self, ar : NumpyFloat, total_sum: Literal[True], a0 : NumpyFloat | None = None
     ) -> np.float64: ...
     @overload
     def asymptotic_expected_net_present_value(
-        self, total_sum: bool = False
+        self, ar : NumpyFloat, total_sum: bool = False, a0 : NumpyFloat | None = None
     ) -> np.float64 | NDArray[np.float64]: ...
-
-    @requires_ar
     def asymptotic_expected_net_present_value(
-        self, total_sum: bool = False
+        self, ar : NumpyFloat, total_sum: bool = False, a0 : NumpyFloat | None = None
     ) -> np.float64 | NDArray[np.float64]:
         return (
-            self._expected_costs.asymptotic_expected_net_present_value()
+            self._expected_costs(ar=ar).asymptotic_expected_net_present_value(total_sum,ar=ar,a0=a0)
         )  # () or (m, nb_steps)
 
-    @requires_valid_periods
-    @requires_ar
+
     def expected_equivalent_annual_cost(
-        self, tf: float, nb_steps: int, total_sum: bool = False
+        self, ar : NumpyFloat, tf: float, nb_steps: int, total_sum: bool = False, a0 : NumpyFloat | None = None
     ) -> tuple[NDArray[np.float64], NDArray[np.float64]]:
 
-        timeline, eeac = self._expected_costs.expected_equivalent_annual_cost(
-            tf, nb_steps
+        timeline, eeac = self._expected_costs(ar=ar).expected_equivalent_annual_cost(
+            tf, nb_steps, ar=ar, a0=a0
         )
-        if eeac.ndim == 2:  # more than one asset
-            eeac[np.where(self.ar == np.inf)[0], :] = np.nan
-        if eeac.ndim == 1 and self.ar == np.inf:
-            eeac.fill(np.nan)
         return (
             timeline,
             eeac,
@@ -382,33 +319,26 @@ class OneCycleAgeReplacementPolicy(BaseAgeReplacementPolicy):
 
     @overload
     def asymptotic_expected_equivalent_annual_cost(
-        self, total_sum: Literal[False]
+        self, ar : NumpyFloat, total_sum: Literal[False], a0 : NumpyFloat | None = None
     ) -> NDArray[np.float64]: ...
     @overload
     def asymptotic_expected_equivalent_annual_cost(
-        self, total_sum: Literal[True]
+        self, ar : NumpyFloat, total_sum: Literal[True], a0 : NumpyFloat | None = None
     ) -> np.float64: ...
     @overload
     def asymptotic_expected_equivalent_annual_cost(
-        self, total_sum: bool = False
+        self, ar : NumpyFloat, total_sum: bool = False, a0 : NumpyFloat | None = None
     ) -> np.float64 | NDArray[np.float64]: ...
-
-    @requires_valid_periods
-    @requires_ar
     def asymptotic_expected_equivalent_annual_cost(
-        self, total_sum: bool = False
+        self, ar : NumpyFloat, total_sum: bool = False, a0 : NumpyFloat | None = None
     ) -> np.float64 | NDArray[np.float64]:
 
         asymptotic_eeac = (
-            self._expected_costs.asymptotic_expected_equivalent_annual_cost()
+            self._expected_costs(ar=ar).asymptotic_expected_equivalent_annual_cost(total_sum,ar=ar,a0=a0)
         )
-        if asymptotic_eeac.ndim == 1:  # more than one asset
-            asymptotic_eeac[np.where(self.ar == np.inf)[0]] = np.nan
-        if asymptotic_eeac.ndim == 0 and self.ar == np.inf:
-            asymptotic_eeac = np.array(np.nan)
         return asymptotic_eeac  # () or (m, nb_steps)
 
-    def optimize(self) -> Self:
+    def compute_optimal_ar(self) -> NumpyFloat:
         """
         Optimize the policy according the costs, the discounting rate and the underlying lifetime model.
 
@@ -444,8 +374,7 @@ class OneCycleAgeReplacementPolicy(BaseAgeReplacementPolicy):
             )
 
         # no idea on how to type eq
-        self.ar = newton(eq, x0)  # () or (m, 1) # pyright:ignore
-        return self
+        return newton(eq, x0)  # () or (m, 1) # pyright:ignore
 
 
 class AgeReplacementPolicy(BaseAgeReplacementPolicy):
@@ -453,9 +382,6 @@ class AgeReplacementPolicy(BaseAgeReplacementPolicy):
 
     Asset is replaced at a fixed age :math:`a_r` with cost :math:`c_p` or it is replaced
     upon failure with cost :math:`c_f`.
-
-    The object's methods require the ``ar`` attribute to be set either at the instanciation
-    or by calling the ``optimize`` method. Otherwise, an error will be raised.
 
     Parameters
     ----------
@@ -467,18 +393,11 @@ class AgeReplacementPolicy(BaseAgeReplacementPolicy):
         Costs of preventive replacements
     discounting_rate : float, default is 0.
         The discounting rate value used in the exponential discounting function
-    a0 : float or 1darray, optional
-        Current ages of the assets. If it is given, left truncations of ``a0`` will
-        be take into account for the first cycle.
-    ar : float or 1darray, optional
-        Ages of preventive replacements, by default None. If not given, one must call ``optimize`` to set ``ar`` values
-        and access to the rest of the object interface.
 
     Attributes
     ----------
     cf
     cp
-    ar
 
     References
     ----------
@@ -487,94 +406,79 @@ class AgeReplacementPolicy(BaseAgeReplacementPolicy):
         Reliability, 1000-1008.
     """
 
-    @property
-    @requires_ar
-    def _stochastic_process(self) -> RenewalRewardProcess:
+    def _stochastic_reward_process(self, ar: NumpyFloat) -> RenewalRewardProcess:
         return RenewalRewardProcess(
                 self.baseline_model,
-                AgeReplacementReward(self.cf,self.cp,self.ar),
+                AgeReplacementReward(self.cf,self.cp,ar),
                 discounting_rate=self.discounting_rate,
             )
 
-    @requires_ar
     def expected_net_present_value(
-        self, tf: float, nb_steps: int, total_sum: bool = False
+        self, ar : NumpyFloat, tf: float, nb_steps: int, total_sum: bool = False, a0 : NumpyFloat | None = None
     ) -> tuple[NDArray[np.float64], NDArray[np.float64]]:
-        timeline, npv = self._stochastic_process.expected_total_reward(tf, nb_steps, a0=self.a0, ar=self.ar)
+        timeline, npv = self._stochastic_reward_process(ar=ar).expected_total_reward(tf, nb_steps, a0=a0, ar=ar)
         if total_sum and npv.ndim == 2:
             npv = np.sum(npv, axis=0)
         return timeline, npv
 
     @overload
     def asymptotic_expected_net_present_value(
-        self, total_sum: Literal[False]
+        self, ar : NumpyFloat, total_sum: Literal[False], a0 : NumpyFloat | None = None
     ) -> NDArray[np.float64]: ...
     @overload
     def asymptotic_expected_net_present_value(
-        self, total_sum: Literal[True]
+        self, ar : NumpyFloat, total_sum: Literal[True], a0 : NumpyFloat | None = None
     ) -> np.float64: ...
     @overload
     def asymptotic_expected_net_present_value(
-        self, total_sum: bool = False
+        self, ar : NumpyFloat, total_sum: bool = False, a0 : NumpyFloat | None = None
     ) -> np.float64 | NDArray[np.float64]: ...
     def asymptotic_expected_net_present_value(
-        self, total_sum: bool = False
+        self, ar : NumpyFloat, total_sum: bool = False, a0 : NumpyFloat | None = None
     ) -> np.float64 | NDArray[np.float64]:
         asymptotic_npv = (
-            self._stochastic_process.asymptotic_expected_total_reward(a0=self.a0, ar=self.ar)
+            self._stochastic_reward_process(ar=ar).asymptotic_expected_total_reward(a0=a0, ar=ar)
         )  # () or (m,)
         if total_sum:
             asymptotic_npv = np.sum(asymptotic_npv)
         return asymptotic_npv
 
-    @requires_valid_periods
-    @requires_ar
     def expected_equivalent_annual_cost(
-        self, tf: float, nb_steps: int, total_sum: bool = False
+        self, ar : NumpyFloat, tf: float, nb_steps: int, total_sum: bool = False, a0 : NumpyFloat | None = None
     ) -> tuple[NDArray[np.float64], NDArray[np.float64]]:
 
-        timeline, eeac = self._stochastic_process.expected_equivalent_annual_worth(
-            tf, nb_steps, a0=self.a0, ar=self.ar
+        timeline, eeac = self._stochastic_reward_process(ar=ar).expected_equivalent_annual_worth(
+            tf, nb_steps, a0=a0, ar=ar
         )
-        if eeac.ndim == 2:
-            eeac[np.where(np.atleast_1d(self.tr1) == 0)] = np.nan
-        if eeac.ndim == 1 and self.ar == np.inf:
-            eeac.fill(np.nan)
         if total_sum and eeac.ndim == 2:
             eeac = np.sum(eeac, axis=0)
         return timeline, eeac  # (nb_steps,), (nb_steps,) or (nb_steps,), (m, nb_steps)
 
     @overload
     def asymptotic_expected_equivalent_annual_cost(
-        self, total_sum: Literal[False]
+        self, ar : NumpyFloat, total_sum: Literal[False], a0 : NumpyFloat | None = None
     ) -> NDArray[np.float64]: ...
     @overload
     def asymptotic_expected_equivalent_annual_cost(
-        self, total_sum: Literal[True]
+        self, ar : NumpyFloat, total_sum: Literal[True], a0 : NumpyFloat | None = None
     ) -> np.float64: ...
     @overload
     def asymptotic_expected_equivalent_annual_cost(
-        self, total_sum: bool = False
+        self, ar : NumpyFloat, total_sum: bool = False, a0 : NumpyFloat | None = None
     ) -> np.float64 | NDArray[np.float64]: ...
 
-    @requires_valid_periods
-    @requires_ar
     def asymptotic_expected_equivalent_annual_cost(
-        self, total_sum: bool = False
+        self, ar : NumpyFloat, total_sum: bool = False, a0 : NumpyFloat | None = None
     ) -> np.float64 | NDArray[np.float64]:
 
         asymptotic_eeac = (
-            self._stochastic_process.asymptotic_expected_equivalent_annual_worth(a0=self.a0,ar=self.ar)
+            self._stochastic_reward_process(ar=ar).asymptotic_expected_equivalent_annual_worth(a0=a0,ar=ar)
         )
-        if asymptotic_eeac.ndim == 1:
-            asymptotic_eeac[np.where(self.tr1 == 0)] = np.nan
-        if asymptotic_eeac.ndim == 0 and self.tr1 == 0:
-            asymptotic_eeac = np.array(np.nan)
         if total_sum:
             asymptotic_eeac = np.sum(asymptotic_eeac)
         return asymptotic_eeac  # () or (m,)
 
-    def annual_number_of_replacements(self, nb_years, upon_failure=False, total=True):
+    def annual_number_of_replacements(self, ar : NumpyFloat, nb_years : int, upon_failure=False, total=True, a0 : NumpyFloat | None = None):
         """
         The expected number of annual replacements.
 
@@ -588,7 +492,7 @@ class AgeReplacementPolicy(BaseAgeReplacementPolicy):
             If True, the given numbers of replacements are the sum of all replacements without distinction between assets
         """
         
-        timeline, total_renewals = self._stochastic_process.renewal_function(nb_years,nb_years+1,a0=self.a0,ar=self.ar)
+        timeline, total_renewals = self._stochastic_reward_process(ar=ar).renewal_function(nb_years,nb_years+1,a0=a0,ar=ar)
         if total:
             mt = np.sum(np.atleast_2d(total_renewals), axis=0)
         else:
@@ -596,7 +500,7 @@ class AgeReplacementPolicy(BaseAgeReplacementPolicy):
         nb_replacements = np.diff(mt)
         if upon_failure:
 
-            _, failures_only = self._stochastic_process.expected_number_of_events(nb_years,nb_years+1,a0=self.a0,ar=self.ar)
+            _, failures_only = self._stochastic_reward_process(ar=ar).expected_number_of_events(nb_years,nb_years+1,a0=a0,ar=ar)
             if total:
                 mf = np.sum(np.atleast_2d(failures_only), axis=0)
             else:
@@ -605,7 +509,7 @@ class AgeReplacementPolicy(BaseAgeReplacementPolicy):
             return timeline[1:], nb_replacements, nb_failures
         return timeline[1:], nb_replacements
 
-    def optimize(self) -> Self:
+    def compute_optimal_ar(self) -> NumpyFloat:
         """
         Optimize the policy according the costs, the discounting rate and the underlying lifetime model.
 
@@ -648,12 +552,10 @@ class AgeReplacementPolicy(BaseAgeReplacementPolicy):
                 / f**2
             )
 
-        # no idea on how to type eq properly
-        self.ar = newton(eq, x0)  # () or (m, 1)  # pyright: ignore
-        return self
+        return newton(eq, x0) # pyright: ignore
 
     def generate_failure_data(
-        self, nb_samples: int, time_window: tuple[float, float], seed=None
+        self, ar : NumpyFloat, nb_samples: int, time_window: tuple[float, float], a0 : NumpyFloat | None = None, seed=None,
     ):
         """Generate failure data
 
@@ -673,11 +575,11 @@ class AgeReplacementPolicy(BaseAgeReplacementPolicy):
         A dict of time, event, entry and args (covariates)
 
         """
-        return self._stochastic_process.generate_failure_data(
-            nb_samples, time_window, seed
+        return self._stochastic_reward_process(ar=ar).generate_failure_data(
+            nb_samples, time_window, ar=ar, a0=a0, seed=seed
         )
 
-    def sample(self, nb_samples: int, time_window: tuple[float, float], seed=None):
+    def sample(self, ar : NumpyFloat, nb_samples: int, time_window: tuple[float, float], a0 : NumpyFloat | None = None, seed=None):
         """Renewal data sampling.
 
         This function will sample data and encapsulate them in an object.
@@ -693,7 +595,7 @@ class AgeReplacementPolicy(BaseAgeReplacementPolicy):
 
         """
 
-        return self._stochastic_process.sample(nb_samples, time_window, seed)
+        return self._stochastic_reward_process(ar=ar).sample(nb_samples, time_window, ar=ar, a0=a0, seed=seed)
 
 
 class NonHomogeneousPoissonAgeReplacementPolicy(ReplacementPolicy):

--- a/src/relife/policy/_preventive_age_replacement.py
+++ b/src/relife/policy/_preventive_age_replacement.py
@@ -1,10 +1,9 @@
 # pyright: basic
 from __future__ import annotations
 
-import warnings
-from abc import ABC
-from typing import Any, Literal, Optional, Self, overload
 import functools
+from abc import ABC
+from typing import Any, Literal, overload
 
 import numpy as np
 from numpy.typing import NDArray
@@ -13,9 +12,7 @@ from scipy.optimize import newton
 from relife.economic import AgeReplacementReward, ExponentialDiscounting
 from relife.lifetime_model import (
     AgeReplacementModel,
-    LeftTruncatedModel,
 )
-from relife.lifetime_model._conditional_model import get_conditional_lifetime_model
 from relife.stochastic_process import RenewalRewardProcess
 from relife.stochastic_process.non_homogeneous_poisson_process import (
     FrozenNonHomogeneousPoissonProcess,
@@ -45,6 +42,7 @@ def check_impossible_replacements(func):
     def wrapper(*args, **kwargs):
         # Get ar and a0
         import inspect
+
         sig = inspect.signature(func)
         bound = sig.bind(*args, **kwargs)
         bound.apply_defaults()
@@ -57,12 +55,12 @@ def check_impossible_replacements(func):
         if a0 is not None:
             if not (np.atleast_1d(ar) >= np.atleast_1d(a0)).all():
                 raise ValueError(
-                    f"Some assets are using an optimal age of replacement inferior to their current age. Please consider changing the age of replacement."
+                    "Some assets are using an optimal age of replacement inferior to their current age. Please consider changing the age of replacement."
                 )
 
         return func(*args, **kwargs)
-    return wrapper
 
+    return wrapper
 
 
 @overload
@@ -200,7 +198,6 @@ class BaseAgeReplacementPolicy(ReplacementPolicy[AnyParametricLifetimeModel[()]]
         self._cost_structure["cp"] = reshape_1d_arg(value)
 
 
-
 class OneCycleAgeReplacementPolicy(BaseAgeReplacementPolicy):
     r"""One-cyle age replacement policy.
 
@@ -256,24 +253,25 @@ class OneCycleAgeReplacementPolicy(BaseAgeReplacementPolicy):
         discounting_rate: float = 0.0,
         period_before_discounting: float = 1.0,
     ):
-        super().__init__(
-            lifetime_model, cf, cp, discounting_rate=discounting_rate
-        )
+        super().__init__(lifetime_model, cf, cp, discounting_rate=discounting_rate)
         self.period_before_discounting = period_before_discounting
 
-    def _expected_costs(self, ar : NumpyFloat) -> OneCycleExpectedCosts:
+    def _expected_costs(self, ar: NumpyFloat) -> OneCycleExpectedCosts:
         return OneCycleExpectedCosts(
             self.baseline_model,
-            AgeReplacementReward(
-                self.cf, self.cp, ar
-            ),
+            AgeReplacementReward(self.cf, self.cp, ar),
             discounting_rate=self.discounting_rate,
-            period_before_discounting=self.period_before_discounting
+            period_before_discounting=self.period_before_discounting,
         )
 
     @check_impossible_replacements
     def expected_net_present_value(
-        self, ar : NumpyFloat, tf: float, nb_steps: int, total_sum: bool = False, a0 : NumpyFloat | None = None
+        self,
+        ar: NumpyFloat,
+        tf: float,
+        nb_steps: int,
+        total_sum: bool = False,
+        a0: NumpyFloat | None = None,
     ) -> tuple[NDArray[np.float64], NDArray[np.float64]]:
         return self._expected_costs(ar=ar).expected_net_present_value(
             tf, nb_steps, total_sum=total_sum, ar=ar, a0=a0
@@ -281,28 +279,33 @@ class OneCycleAgeReplacementPolicy(BaseAgeReplacementPolicy):
 
     @overload
     def asymptotic_expected_net_present_value(
-        self, ar : NumpyFloat, total_sum: Literal[False], a0 : NumpyFloat | None = None
+        self, ar: NumpyFloat, total_sum: Literal[False], a0: NumpyFloat | None = None
     ) -> NDArray[np.float64]: ...
     @overload
     def asymptotic_expected_net_present_value(
-        self, ar : NumpyFloat, total_sum: Literal[True], a0 : NumpyFloat | None = None
+        self, ar: NumpyFloat, total_sum: Literal[True], a0: NumpyFloat | None = None
     ) -> np.float64: ...
     @overload
     def asymptotic_expected_net_present_value(
-        self, ar : NumpyFloat, total_sum: bool = False, a0 : NumpyFloat | None = None
+        self, ar: NumpyFloat, total_sum: bool = False, a0: NumpyFloat | None = None
     ) -> np.float64 | NDArray[np.float64]: ...
 
     @check_impossible_replacements
     def asymptotic_expected_net_present_value(
-        self, ar : NumpyFloat, total_sum: bool = False, a0 : NumpyFloat | None = None
+        self, ar: NumpyFloat, total_sum: bool = False, a0: NumpyFloat | None = None
     ) -> np.float64 | NDArray[np.float64]:
-        return (
-            self._expected_costs(ar=ar).asymptotic_expected_net_present_value(total_sum,ar=ar,a0=a0)
+        return self._expected_costs(ar=ar).asymptotic_expected_net_present_value(
+            total_sum, ar=ar, a0=a0
         )  # () or (m, nb_steps)
 
     @check_impossible_replacements
     def expected_equivalent_annual_cost(
-        self, ar : NumpyFloat, tf: float, nb_steps: int, total_sum: bool = False, a0 : NumpyFloat | None = None
+        self,
+        ar: NumpyFloat,
+        tf: float,
+        nb_steps: int,
+        total_sum: bool = False,
+        a0: NumpyFloat | None = None,
     ) -> tuple[NDArray[np.float64], NDArray[np.float64]]:
 
         timeline, eeac = self._expected_costs(ar=ar).expected_equivalent_annual_cost(
@@ -315,25 +318,25 @@ class OneCycleAgeReplacementPolicy(BaseAgeReplacementPolicy):
 
     @overload
     def asymptotic_expected_equivalent_annual_cost(
-        self, ar : NumpyFloat, total_sum: Literal[False], a0 : NumpyFloat | None = None
+        self, ar: NumpyFloat, total_sum: Literal[False], a0: NumpyFloat | None = None
     ) -> NDArray[np.float64]: ...
     @overload
     def asymptotic_expected_equivalent_annual_cost(
-        self, ar : NumpyFloat, total_sum: Literal[True], a0 : NumpyFloat | None = None
+        self, ar: NumpyFloat, total_sum: Literal[True], a0: NumpyFloat | None = None
     ) -> np.float64: ...
     @overload
     def asymptotic_expected_equivalent_annual_cost(
-        self, ar : NumpyFloat, total_sum: bool = False, a0 : NumpyFloat | None = None
+        self, ar: NumpyFloat, total_sum: bool = False, a0: NumpyFloat | None = None
     ) -> np.float64 | NDArray[np.float64]: ...
 
     @check_impossible_replacements
     def asymptotic_expected_equivalent_annual_cost(
-        self, ar : NumpyFloat, total_sum: bool = False, a0 : NumpyFloat | None = None
+        self, ar: NumpyFloat, total_sum: bool = False, a0: NumpyFloat | None = None
     ) -> np.float64 | NDArray[np.float64]:
 
-        asymptotic_eeac = (
-            self._expected_costs(ar=ar).asymptotic_expected_equivalent_annual_cost(total_sum,ar=ar,a0=a0)
-        )
+        asymptotic_eeac = self._expected_costs(
+            ar=ar
+        ).asymptotic_expected_equivalent_annual_cost(total_sum, ar=ar, a0=a0)
         return asymptotic_eeac  # () or (m, nb_steps)
 
     def compute_optimal_ar(self) -> NumpyFloat:
@@ -406,83 +409,102 @@ class AgeReplacementPolicy(BaseAgeReplacementPolicy):
 
     def _stochastic_reward_process(self, ar: NumpyFloat) -> RenewalRewardProcess:
         return RenewalRewardProcess(
-                self.baseline_model,
-                AgeReplacementReward(self.cf,self.cp,ar),
-                discounting_rate=self.discounting_rate,
-            )
+            self.baseline_model,
+            AgeReplacementReward(self.cf, self.cp, ar),
+            discounting_rate=self.discounting_rate,
+        )
 
     @check_impossible_replacements
     def expected_net_present_value(
-        self, ar : NumpyFloat, tf: float, nb_steps: int, total_sum: bool = False, a0 : NumpyFloat | None = None
+        self,
+        ar: NumpyFloat,
+        tf: float,
+        nb_steps: int,
+        total_sum: bool = False,
+        a0: NumpyFloat | None = None,
     ) -> tuple[NDArray[np.float64], NDArray[np.float64]]:
-        timeline, npv = self._stochastic_reward_process(ar=ar).expected_total_reward(tf, nb_steps, a0=a0, ar=ar)
+        timeline, npv = self._stochastic_reward_process(ar=ar).expected_total_reward(
+            tf, nb_steps, a0=a0, ar=ar
+        )
         if total_sum and npv.ndim == 2:
             npv = np.sum(npv, axis=0)
         return timeline, npv
 
     @overload
     def asymptotic_expected_net_present_value(
-        self, ar : NumpyFloat, total_sum: Literal[False], a0 : NumpyFloat | None = None
+        self, ar: NumpyFloat, total_sum: Literal[False], a0: NumpyFloat | None = None
     ) -> NDArray[np.float64]: ...
     @overload
     def asymptotic_expected_net_present_value(
-        self, ar : NumpyFloat, total_sum: Literal[True], a0 : NumpyFloat | None = None
+        self, ar: NumpyFloat, total_sum: Literal[True], a0: NumpyFloat | None = None
     ) -> np.float64: ...
     @overload
     def asymptotic_expected_net_present_value(
-        self, ar : NumpyFloat, total_sum: bool = False, a0 : NumpyFloat | None = None
+        self, ar: NumpyFloat, total_sum: bool = False, a0: NumpyFloat | None = None
     ) -> np.float64 | NDArray[np.float64]: ...
 
     @check_impossible_replacements
     def asymptotic_expected_net_present_value(
-        self, ar : NumpyFloat, total_sum: bool = False, a0 : NumpyFloat | None = None
+        self, ar: NumpyFloat, total_sum: bool = False, a0: NumpyFloat | None = None
     ) -> np.float64 | NDArray[np.float64]:
-        asymptotic_npv = (
-            self._stochastic_reward_process(ar=ar).asymptotic_expected_total_reward(a0=a0, ar=ar)
-        )  # () or (m,)
+        asymptotic_npv = self._stochastic_reward_process(
+            ar=ar
+        ).asymptotic_expected_total_reward(a0=a0, ar=ar)  # () or (m,)
         if total_sum:
             asymptotic_npv = np.sum(asymptotic_npv)
         return asymptotic_npv
 
     @check_impossible_replacements
     def expected_equivalent_annual_cost(
-        self, ar : NumpyFloat, tf: float, nb_steps: int, total_sum: bool = False, a0 : NumpyFloat | None = None
+        self,
+        ar: NumpyFloat,
+        tf: float,
+        nb_steps: int,
+        total_sum: bool = False,
+        a0: NumpyFloat | None = None,
     ) -> tuple[NDArray[np.float64], NDArray[np.float64]]:
 
-        timeline, eeac = self._stochastic_reward_process(ar=ar).expected_equivalent_annual_worth(
-            tf, nb_steps, a0=a0, ar=ar
-        )
+        timeline, eeac = self._stochastic_reward_process(
+            ar=ar
+        ).expected_equivalent_annual_worth(tf, nb_steps, a0=a0, ar=ar)
         if total_sum and eeac.ndim == 2:
             eeac = np.sum(eeac, axis=0)
         return timeline, eeac  # (nb_steps,), (nb_steps,) or (nb_steps,), (m, nb_steps)
 
     @overload
     def asymptotic_expected_equivalent_annual_cost(
-        self, ar : NumpyFloat, total_sum: Literal[False], a0 : NumpyFloat | None = None
+        self, ar: NumpyFloat, total_sum: Literal[False], a0: NumpyFloat | None = None
     ) -> NDArray[np.float64]: ...
     @overload
     def asymptotic_expected_equivalent_annual_cost(
-        self, ar : NumpyFloat, total_sum: Literal[True], a0 : NumpyFloat | None = None
+        self, ar: NumpyFloat, total_sum: Literal[True], a0: NumpyFloat | None = None
     ) -> np.float64: ...
     @overload
     def asymptotic_expected_equivalent_annual_cost(
-        self, ar : NumpyFloat, total_sum: bool = False, a0 : NumpyFloat | None = None
+        self, ar: NumpyFloat, total_sum: bool = False, a0: NumpyFloat | None = None
     ) -> np.float64 | NDArray[np.float64]: ...
 
     @check_impossible_replacements
     def asymptotic_expected_equivalent_annual_cost(
-        self, ar : NumpyFloat, total_sum: bool = False, a0 : NumpyFloat | None = None
+        self, ar: NumpyFloat, total_sum: bool = False, a0: NumpyFloat | None = None
     ) -> np.float64 | NDArray[np.float64]:
 
-        asymptotic_eeac = (
-            self._stochastic_reward_process(ar=ar).asymptotic_expected_equivalent_annual_worth(a0=a0,ar=ar)
-        )
+        asymptotic_eeac = self._stochastic_reward_process(
+            ar=ar
+        ).asymptotic_expected_equivalent_annual_worth(a0=a0, ar=ar)
         if total_sum:
             asymptotic_eeac = np.sum(asymptotic_eeac)
         return asymptotic_eeac  # () or (m,)
 
     @check_impossible_replacements
-    def annual_number_of_replacements(self, ar : NumpyFloat, nb_years : int, upon_failure=False, total=True, a0 : NumpyFloat | None = None):
+    def annual_number_of_replacements(
+        self,
+        ar: NumpyFloat,
+        nb_years: int,
+        upon_failure=False,
+        total=True,
+        a0: NumpyFloat | None = None,
+    ):
         """
         The expected number of annual replacements.
 
@@ -495,16 +517,19 @@ class AgeReplacementPolicy(BaseAgeReplacementPolicy):
         total : bool, default is True
             If True, the given numbers of replacements are the sum of all replacements without distinction between assets
         """
-        
-        timeline, total_renewals = self._stochastic_reward_process(ar=ar).renewal_function(nb_years,nb_years+1,a0=a0,ar=ar)
+
+        timeline, total_renewals = self._stochastic_reward_process(
+            ar=ar
+        ).renewal_function(nb_years, nb_years + 1, a0=a0, ar=ar)
         if total:
             mt = np.sum(np.atleast_2d(total_renewals), axis=0)
         else:
             mt = total_renewals
         nb_replacements = np.diff(mt)
         if upon_failure:
-
-            _, failures_only = self._stochastic_reward_process(ar=ar).expected_number_of_events(nb_years,nb_years+1,a0=a0,ar=ar)
+            _, failures_only = self._stochastic_reward_process(
+                ar=ar
+            ).expected_number_of_events(nb_years, nb_years + 1, a0=a0, ar=ar)
             if total:
                 mf = np.sum(np.atleast_2d(failures_only), axis=0)
             else:
@@ -556,11 +581,16 @@ class AgeReplacementPolicy(BaseAgeReplacementPolicy):
                 / f**2
             )
 
-        return newton(eq, x0) # pyright: ignore
+        return newton(eq, x0)  # pyright: ignore
 
     @check_impossible_replacements
     def generate_failure_data(
-        self, ar : NumpyFloat, nb_samples: int, time_window: tuple[float, float], a0 : NumpyFloat | None = None, seed=None,
+        self,
+        ar: NumpyFloat,
+        nb_samples: int,
+        time_window: tuple[float, float],
+        a0: NumpyFloat | None = None,
+        seed=None,
     ):
         """Generate failure data
 
@@ -585,7 +615,14 @@ class AgeReplacementPolicy(BaseAgeReplacementPolicy):
         )
 
     @check_impossible_replacements
-    def sample(self, ar : NumpyFloat, nb_samples: int, time_window: tuple[float, float], a0 : NumpyFloat | None = None, seed=None):
+    def sample(
+        self,
+        ar: NumpyFloat,
+        nb_samples: int,
+        time_window: tuple[float, float],
+        a0: NumpyFloat | None = None,
+        seed=None,
+    ):
         """Renewal data sampling.
 
         This function will sample data and encapsulate them in an object.
@@ -601,7 +638,9 @@ class AgeReplacementPolicy(BaseAgeReplacementPolicy):
 
         """
 
-        return self._stochastic_reward_process(ar=ar).sample(nb_samples, time_window, ar=ar, a0=a0, seed=seed)
+        return self._stochastic_reward_process(ar=ar).sample(
+            nb_samples, time_window, ar=ar, a0=a0, seed=seed
+        )
 
 
 class NonHomogeneousPoissonAgeReplacementPolicy(ReplacementPolicy):
@@ -685,13 +724,13 @@ class NonHomogeneousPoissonAgeReplacementPolicy(ReplacementPolicy):
             self._ar = None
 
     def expected_net_present_value(self, tf, nb_steps, total_sum=False):
-        raise NotImplemented("implementation will come in a future release")
+        raise NotImplementedError("implementation will come in a future release")
 
     def asymptotic_expected_net_present_value(self, total_sum=False):
-        raise NotImplemented("implementation will come in a future release")
+        raise NotImplementedError("implementation will come in a future release")
 
     def expected_equivalent_annual_cost(self, tf, nb_steps, total_sum=False):
-        raise NotImplemented("implementation will come in a future release")
+        raise NotImplementedError("implementation will come in a future release")
 
     def asymptotic_expected_equivalent_annual_cost(self):
         discounting = ExponentialDiscounting(self.discounting_rate)
@@ -714,8 +753,9 @@ class NonHomogeneousPoissonAgeReplacementPolicy(ReplacementPolicy):
                     self.cp * discounting.factor(self._ar)
                     + self.cr
                     * legendre_quadrature(
-                        lambda t: discounting.factor(t)
-                        * self.baseline_model.intensity(t),
+                        lambda t: (
+                            discounting.factor(t) * self.baseline_model.intensity(t)
+                        ),
                         0,
                         self._ar,
                     )
@@ -744,8 +784,9 @@ class NonHomogeneousPoissonAgeReplacementPolicy(ReplacementPolicy):
                     / self.discounting_rate
                     * self.baseline_model.intensity(a)
                     - legendre_quadrature(
-                        lambda t: discounting.factor(t)
-                        * self.baseline_model.intensity(t),
+                        lambda t: (
+                            discounting.factor(t) * self.baseline_model.intensity(t)
+                        ),
                         np.array(0.0),
                         a,
                     )

--- a/src/relife/policy/_preventive_age_replacement.py
+++ b/src/relife/policy/_preventive_age_replacement.py
@@ -309,7 +309,7 @@ class OneCycleAgeReplacementPolicy(BaseAgeReplacementPolicy):
     ) -> tuple[NDArray[np.float64], NDArray[np.float64]]:
 
         timeline, eeac = self._expected_costs(ar=ar).expected_equivalent_annual_cost(
-            tf, nb_steps, ar=ar, a0=a0
+            tf, nb_steps, total_sum=total_sum,ar=ar, a0=a0
         )
         return (
             timeline,

--- a/src/relife/policy/_preventive_age_replacement.py
+++ b/src/relife/policy/_preventive_age_replacement.py
@@ -667,13 +667,12 @@ class NonHomogeneousPoissonAgeReplacementPolicy(ReplacementPolicy):
     ar
     """
 
-    def __init__(self, nhpp, cr, cp, discounting_rate=0.0, ar=None):
+    def __init__(self, nhpp, cr, cp, discounting_rate=0.0):
         super().__init__(
             nhpp,
             cost_structure={"cr": reshape_1d_arg(cr), "cp": reshape_1d_arg(cp)},
             discounting_rate=discounting_rate,
         )
-        self.ar = ar
 
     @property
     def cp(self):
@@ -703,64 +702,41 @@ class NonHomogeneousPoissonAgeReplacementPolicy(ReplacementPolicy):
     def cr(self, value):
         self._cost_structure["cr"] = reshape_1d_arg(value)
 
-    @property
-    def ar(self):
-        """Preventive ages of replacement.
-
-        Returns
-        -------
-        np.ndarray
-        """
-        if self._ar is None:
-            return self._ar
-        return flatten_if_possible(self._ar)
-
-    @ar.setter
-    def ar(self, value):
-        if value is not None:
-            value = reshape_1d_arg(value)
-            self._ar = value
-        else:
-            self._ar = None
-
-    def expected_net_present_value(self, tf, nb_steps, total_sum=False):
+    def expected_net_present_value(self, tf, ar : NumpyFloat, nb_steps, total_sum=False, a0: NumpyFloat | None = None):
         raise NotImplementedError("implementation will come in a future release")
 
-    def asymptotic_expected_net_present_value(self, total_sum=False):
+    def asymptotic_expected_net_present_value(self, ar : NumpyFloat, total_sum=False, a0: NumpyFloat | None = None):
         raise NotImplementedError("implementation will come in a future release")
 
-    def expected_equivalent_annual_cost(self, tf, nb_steps, total_sum=False):
+    def expected_equivalent_annual_cost(self, ar : NumpyFloat, tf, nb_steps, total_sum=False, a0: NumpyFloat | None = None):
         raise NotImplementedError("implementation will come in a future release")
 
-    def asymptotic_expected_equivalent_annual_cost(self):
+    def asymptotic_expected_equivalent_annual_cost(self, ar : NumpyFloat, a0: NumpyFloat | None = None):
         discounting = ExponentialDiscounting(self.discounting_rate)
-
-        if self.ar is None:
-            raise ValueError
 
         if self.discounting_rate == 0.0:
             asymptotic_eeac = (
                 self.cp
                 + self.cr
                 * legendre_quadrature(
-                    lambda t: self.baseline_model.intensity(t), 0, self._ar
+                    lambda t: self.baseline_model.intensity(t), 0, ar
                 )
-            ) / self._ar
+            ) / ar
         else:
             asymptotic_eeac = (
                 self.discounting_rate
                 * (
-                    self.cp * discounting.factor(self._ar)
+                    self.cp * discounting.factor(ar)
                     + self.cr
                     * legendre_quadrature(
                         lambda t: (
                             discounting.factor(t) * self.baseline_model.intensity(t)
                         ),
                         0,
-                        self._ar,
+                        ar,
                     )
                 )
-                / (1 - discounting.factor(self._ar))
+                / (1 - discounting.factor(ar))
             )
         return np.squeeze(asymptotic_eeac)  # () or (m,)
 

--- a/src/relife/policy/_preventive_age_replacement.py
+++ b/src/relife/policy/_preventive_age_replacement.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import warnings
 from abc import ABC
 from typing import Any, Literal, Optional, Self, overload
+import functools
 
 import numpy as np
 from numpy.typing import NDArray
@@ -36,6 +37,37 @@ __all__ = [
     "AgeReplacementModel",
     "age_replacement_policy",
 ]
+
+
+def requires_ar(method):
+    @functools.wraps(method)
+    def wrapper(self, *args, **kwargs):
+        if not hasattr(self, 'ar') or self.ar is None:
+            raise ValueError(
+                f"Age replacements must be set or optimised before using '{method.__name__}'"
+            )
+        return method(self, *args, **kwargs)
+    return wrapper
+
+
+def requires_valid_periods(method):
+    @functools.wraps(method)
+    def wrapper(self, *args, **kwargs):
+        if np.any(self.period_before_discounting >= self.ar):
+            raise ValueError(
+                "The period before discounting must be lower than age replacement values"
+            )
+        if np.any(self.tr1 == 0):
+            warnings.warn(
+                "Some assets has already been replaced for the first cycle (ar < a0). For these assets, consider manually adjusting age of replacements."
+            )
+            ar = self.ar.copy()
+            self.ar = np.where(self.tr1 == 0, np.inf, self.ar)
+            result = method(self, *args, **kwargs)
+            self.ar = ar
+            return result
+        return method(self, *args, **kwargs)
+    return wrapper
 
 
 @overload
@@ -287,32 +319,24 @@ class OneCycleAgeReplacementPolicy(BaseAgeReplacementPolicy):
         )
         self.period_before_discounting = period_before_discounting
 
-    @property
-    def _expected_costs(self) -> OneCycleExpectedCosts:
-        if self.ar is None or self.tr1 is None:
-            raise ValueError("ar must be set or optimized")
-        else:
-            if self.a0 is None:
-                return OneCycleExpectedCosts(
-                    AgeReplacementModel(self.baseline_model).freeze(self.tr1),
-                    AgeReplacementReward(self.cf, self.cp, self.tr1),
-                    discounting_rate=self.discounting_rate,
-                    period_before_discounting=self.period_before_discounting,
-                )
-            return OneCycleExpectedCosts(
-                AgeReplacementModel(LeftTruncatedModel(self.baseline_model)).freeze(
-                    self.tr1, self.a0
-                ),
-                AgeReplacementReward(self.cf, self.cp, self.tr1),
-                discounting_rate=self.discounting_rate,
-                period_before_discounting=self.period_before_discounting,
-            )
 
+    @property
+    @requires_ar
+    def _expected_costs(self) -> OneCycleExpectedCosts:
+        conditional_model = get_conditional_lifetime_model(self.baseline_model,a0=self.a0)
+        return OneCycleExpectedCosts(
+            conditional_model,
+            AgeReplacementReward(
+                self.cf, self.cp, self.tr1
+            ),
+            discounting_rate=self.discounting_rate,
+            period_before_discounting=self.period_before_discounting
+        )
+
+    @requires_ar
     def expected_net_present_value(
         self, tf: float, nb_steps: int, total_sum: bool = False
     ) -> tuple[NDArray[np.float64], NDArray[np.float64]]:
-        if self.ar is None:
-            raise ValueError
         return self._expected_costs.expected_net_present_value(
             tf, nb_steps, total_sum=total_sum
         )  # (nb_steps,), (nb_steps,) or (nb_steps,), (m, nb_steps)
@@ -329,47 +353,32 @@ class OneCycleAgeReplacementPolicy(BaseAgeReplacementPolicy):
     def asymptotic_expected_net_present_value(
         self, total_sum: bool = False
     ) -> np.float64 | NDArray[np.float64]: ...
+
+    @requires_ar
     def asymptotic_expected_net_present_value(
         self, total_sum: bool = False
     ) -> np.float64 | NDArray[np.float64]:
-        if self.ar is None:
-            raise ValueError
         return (
             self._expected_costs.asymptotic_expected_net_present_value()
         )  # () or (m, nb_steps)
 
+    @requires_valid_periods
+    @requires_ar
     def expected_equivalent_annual_cost(
         self, tf: float, nb_steps: int, total_sum: bool = False
     ) -> tuple[NDArray[np.float64], NDArray[np.float64]]:
-        if self.ar is None or self.tr1 is None:
-            raise ValueError
-        else:
-            # because b = np.minimum(ar, b) in ls_integrate, b can be lower than a depending on period before discounting
-            if np.any(self.period_before_discounting >= self.ar):
-                raise ValueError(
-                    "The period before discounting must be lower than ar values"
-                )
 
-            if np.any(self.tr1 == 0):
-                warnings.warn(
-                    "Some assets has already been replaced for the first cycle (where tr is 0). For these assets, consider adjusting ar values to be greater than a0"
-                )
-
-            ar = self.ar.copy()
-            #  change ar temporarly to enable computation of eeac (if not, AgeReplacementModel.ls_integrate bounds will be problematic)
-            self.ar = np.where(self.tr1 == 0, np.inf, self.ar)
-            timeline, eeac = self._expected_costs.expected_equivalent_annual_cost(
-                tf, nb_steps
-            )
-            if eeac.ndim == 2:  # more than one asset
-                eeac[np.where(self.ar == np.inf)[0], :] = np.nan
-            if eeac.ndim == 1 and self.ar == np.inf:
-                eeac.fill(np.nan)
-            self.ar = ar
-            return (
-                timeline,
-                eeac,
-            )  # (nb_steps,), (nb_steps,) or (nb_steps,), (m, nb_steps)
+        timeline, eeac = self._expected_costs.expected_equivalent_annual_cost(
+            tf, nb_steps
+        )
+        if eeac.ndim == 2:  # more than one asset
+            eeac[np.where(self.ar == np.inf)[0], :] = np.nan
+        if eeac.ndim == 1 and self.ar == np.inf:
+            eeac.fill(np.nan)
+        return (
+            timeline,
+            eeac,
+        )  # (nb_steps,), (nb_steps,) or (nb_steps,), (m, nb_steps)
 
     @overload
     def asymptotic_expected_equivalent_annual_cost(
@@ -383,34 +392,20 @@ class OneCycleAgeReplacementPolicy(BaseAgeReplacementPolicy):
     def asymptotic_expected_equivalent_annual_cost(
         self, total_sum: bool = False
     ) -> np.float64 | NDArray[np.float64]: ...
+
+    @requires_valid_periods
+    @requires_ar
     def asymptotic_expected_equivalent_annual_cost(
         self, total_sum: bool = False
     ) -> np.float64 | NDArray[np.float64]:
-        if self.ar is None:
-            raise ValueError
-        # because b = np.minimum(ar, b) in ls_integrate, b can be lower than a depending on period before discounting
-        if np.any(self.period_before_discounting >= self.ar):
-            raise ValueError(
-                "The period before discounting must be lower than ar values"
-            )
 
-        if np.any(self.tr1 == 0):
-            warnings.warn(
-                "Some assets has already been replaced for the first cycle (where tr is 0). For these assets, consider adjusting ar values to be greater than a0"
-            )
-
-        ar = self.ar.copy()
-        #  change ar temporarly to enable computation of eeac (if not, AgeReplacementModel.ls_integrate bounds are not in right order)
-        self.ar = np.where(self.tr1 == 0, np.inf, self.ar)
         asymptotic_eeac = (
             self._expected_costs.asymptotic_expected_equivalent_annual_cost()
         )
-
         if asymptotic_eeac.ndim == 1:  # more than one asset
             asymptotic_eeac[np.where(self.ar == np.inf)[0]] = np.nan
         if asymptotic_eeac.ndim == 0 and self.ar == np.inf:
             asymptotic_eeac = np.array(np.nan)
-        self.ar = ar
         return asymptotic_eeac  # () or (m, nb_steps)
 
     def optimize(self) -> Self:
@@ -493,31 +488,21 @@ class AgeReplacementPolicy(BaseAgeReplacementPolicy):
     """
 
     @property
+    @requires_ar
     def _stochastic_process(self) -> RenewalRewardProcess:
-        if self.ar is None or self.tr1 is None:
-            raise ValueError("ar must be set or optimized")
-        if self.a0 is None:
-            return RenewalRewardProcess(
-                AgeReplacementModel(self.baseline_model).freeze(self.ar),
-                AgeReplacementReward(self.cf, self.cp, self.ar),
-                discounting_rate=self.discounting_rate,
-            )
+        first_reward = AgeReplacementReward(self.cf, self.cp, self.tr1) if self.a0 is not None else None
         return RenewalRewardProcess(
-            AgeReplacementModel(self.baseline_model).freeze(self.ar),
-            AgeReplacementReward(self.cf, self.cp, self.ar),
-            discounting_rate=self.discounting_rate,
-            first_lifetime_model=AgeReplacementModel(
-                LeftTruncatedModel(self.baseline_model)
-            ).freeze(self.tr1, self.a0),
-            first_reward=AgeReplacementReward(self.cf, self.cp, self.tr1),
-        )
+                self.baseline_model,
+                AgeReplacementReward(self.cf,self.cp,self.ar),
+                discounting_rate=self.discounting_rate,
+                first_reward=first_reward
+            )
 
+    @requires_ar
     def expected_net_present_value(
         self, tf: float, nb_steps: int, total_sum: bool = False
     ) -> tuple[NDArray[np.float64], NDArray[np.float64]]:
-        if self.ar is None:
-            raise ValueError("ar must be set or optimized")
-        timeline, npv = self._stochastic_process.expected_total_reward(tf, nb_steps)
+        timeline, npv = self._stochastic_process.expected_total_reward(tf, nb_steps, a0=self.a0, ar=self.ar)
         if total_sum and npv.ndim == 2:
             npv = np.sum(npv, axis=0)
         return timeline, npv
@@ -538,25 +523,21 @@ class AgeReplacementPolicy(BaseAgeReplacementPolicy):
         self, total_sum: bool = False
     ) -> np.float64 | NDArray[np.float64]:
         asymptotic_npv = (
-            self._stochastic_process.asymptotic_expected_total_reward()
+            self._stochastic_process.asymptotic_expected_total_reward(a0=self.a0, ar=self.ar)
         )  # () or (m,)
         if total_sum:
             asymptotic_npv = np.sum(asymptotic_npv)
         return asymptotic_npv
 
+    @requires_valid_periods
+    @requires_ar
     def expected_equivalent_annual_cost(
         self, tf: float, nb_steps: int, total_sum: bool = False
     ) -> tuple[NDArray[np.float64], NDArray[np.float64]]:
-        if self.ar is None or self.tr1 is None:
-            raise ValueError
 
         timeline, eeac = self._stochastic_process.expected_equivalent_annual_worth(
-            tf, nb_steps
+            tf, nb_steps, a0=self.a0, ar=self.ar
         )
-        if np.any(self.tr1 == 0):
-            warnings.warn(
-                "Some assets has already been replaced for the first cycle (where tr1 is 0). For these assets, consider adjusting ar values to be greater than a0"
-            )
         if eeac.ndim == 2:
             eeac[np.where(np.atleast_1d(self.tr1) == 0)] = np.nan
         if eeac.ndim == 1 and self.ar == np.inf:
@@ -577,19 +558,16 @@ class AgeReplacementPolicy(BaseAgeReplacementPolicy):
     def asymptotic_expected_equivalent_annual_cost(
         self, total_sum: bool = False
     ) -> np.float64 | NDArray[np.float64]: ...
+
+    @requires_valid_periods
+    @requires_ar
     def asymptotic_expected_equivalent_annual_cost(
         self, total_sum: bool = False
     ) -> np.float64 | NDArray[np.float64]:
-        if self.ar is None or self.tr1 is None:
-            raise ValueError
 
         asymptotic_eeac = (
-            self._stochastic_process.asymptotic_expected_equivalent_annual_worth()
+            self._stochastic_process.asymptotic_expected_equivalent_annual_worth(a0=self.a0,ar=self.ar)
         )
-        if np.any(self.tr1 == 0):
-            warnings.warn(
-                "Some assets has already been replaced for the first cycle (where tr1 is 0). For these assets, consider adjusting ar values to be greater than a0"
-            )
         if asymptotic_eeac.ndim == 1:
             asymptotic_eeac[np.where(self.tr1 == 0)] = np.nan
         if asymptotic_eeac.ndim == 0 and self.tr1 == 0:
@@ -611,38 +589,20 @@ class AgeReplacementPolicy(BaseAgeReplacementPolicy):
         total : bool, default is True
             If True, the given numbers of replacements are the sum of all replacements without distinction between assets
         """
-        copied_policy = self.__class__(
-            self.baseline_model,
-            1.0,
-            1.0,
-            ar=self.ar,
-            a0=self.a0,
-            discounting_rate=0.0,
-        )
-        timeline, total_cost = copied_policy.expected_net_present_value(
-            nb_years, nb_years + 1
-        )  # equiv to np.arange
+        
+        timeline, total_renewals = self._stochastic_process.renewal_function(nb_years,nb_years+1,a0=self.a0,ar=self.ar)
         if total:
-            mt = np.sum(np.atleast_2d(total_cost), axis=0)
+            mt = np.sum(np.atleast_2d(total_renewals), axis=0)
         else:
-            mt = total_cost
+            mt = total_renewals
         nb_replacements = np.diff(mt)
         if upon_failure:
-            copied_policy = self.__class__(
-                self.baseline_model,
-                1.0,
-                0.0,
-                ar=self.ar,
-                a0=self.a0,
-                discounting_rate=0.0,
-            )
-            _, total_cost = copied_policy.expected_net_present_value(
-                nb_years, nb_years + 1
-            )  # equiv to np.arange
+
+            _, failures_only = self._stochastic_process.expected_number_of_events(nb_years,nb_years+1,a0=self.a0,ar=self.ar)
             if total:
-                mf = np.sum(np.atleast_2d(total_cost), axis=0)
+                mf = np.sum(np.atleast_2d(failures_only), axis=0)
             else:
-                mf = total_cost
+                mf = failures_only
             nb_failures = np.diff(mf)
             return timeline[1:], nb_replacements, nb_failures
         return timeline[1:], nb_replacements

--- a/src/relife/policy/_preventive_age_replacement.py
+++ b/src/relife/policy/_preventive_age_replacement.py
@@ -309,7 +309,7 @@ class OneCycleAgeReplacementPolicy(BaseAgeReplacementPolicy):
     ) -> tuple[NDArray[np.float64], NDArray[np.float64]]:
 
         timeline, eeac = self._expected_costs(ar=ar).expected_equivalent_annual_cost(
-            tf, nb_steps, total_sum=total_sum,ar=ar, a0=a0
+            tf, nb_steps, total_sum=total_sum, ar=ar, a0=a0
         )
         return (
             timeline,
@@ -702,25 +702,41 @@ class NonHomogeneousPoissonAgeReplacementPolicy(ReplacementPolicy):
     def cr(self, value):
         self._cost_structure["cr"] = reshape_1d_arg(value)
 
-    def expected_net_present_value(self, tf, ar : NumpyFloat, nb_steps, total_sum=False, a0: NumpyFloat | None = None):
+    def expected_net_present_value(
+        self,
+        tf,
+        ar: NumpyFloat,
+        nb_steps,
+        total_sum=False,
+        a0: NumpyFloat | None = None,
+    ):
         raise NotImplementedError("implementation will come in a future release")
 
-    def asymptotic_expected_net_present_value(self, ar : NumpyFloat, total_sum=False, a0: NumpyFloat | None = None):
+    def asymptotic_expected_net_present_value(
+        self, ar: NumpyFloat, total_sum=False, a0: NumpyFloat | None = None
+    ):
         raise NotImplementedError("implementation will come in a future release")
 
-    def expected_equivalent_annual_cost(self, ar : NumpyFloat, tf, nb_steps, total_sum=False, a0: NumpyFloat | None = None):
+    def expected_equivalent_annual_cost(
+        self,
+        ar: NumpyFloat,
+        tf,
+        nb_steps,
+        total_sum=False,
+        a0: NumpyFloat | None = None,
+    ):
         raise NotImplementedError("implementation will come in a future release")
 
-    def asymptotic_expected_equivalent_annual_cost(self, ar : NumpyFloat, a0: NumpyFloat | None = None):
+    def asymptotic_expected_equivalent_annual_cost(
+        self, ar: NumpyFloat, a0: NumpyFloat | None = None
+    ):
         discounting = ExponentialDiscounting(self.discounting_rate)
 
         if self.discounting_rate == 0.0:
             asymptotic_eeac = (
                 self.cp
                 + self.cr
-                * legendre_quadrature(
-                    lambda t: self.baseline_model.intensity(t), 0, ar
-                )
+                * legendre_quadrature(lambda t: self.baseline_model.intensity(t), 0, ar)
             ) / ar
         else:
             asymptotic_eeac = (

--- a/src/relife/policy/_preventive_age_replacement.py
+++ b/src/relife/policy/_preventive_age_replacement.py
@@ -490,12 +490,10 @@ class AgeReplacementPolicy(BaseAgeReplacementPolicy):
     @property
     @requires_ar
     def _stochastic_process(self) -> RenewalRewardProcess:
-        first_reward = AgeReplacementReward(self.cf, self.cp, self.tr1) if self.a0 is not None else None
         return RenewalRewardProcess(
                 self.baseline_model,
                 AgeReplacementReward(self.cf,self.cp,self.ar),
                 discounting_rate=self.discounting_rate,
-                first_reward=first_reward
             )
 
     @requires_ar

--- a/src/relife/policy/_run_to_failure.py
+++ b/src/relife/policy/_run_to_failure.py
@@ -250,55 +250,46 @@ class RunToFailurePolicy(BaseRunToFailure):
     """
 
     @property
-    def _stochastic_process(self) -> RenewalRewardProcess:
-        if self.a0 is None:
-            return RenewalRewardProcess(
-                self.baseline_model,
-                RunToFailureReward(self.cf),
-                discounting_rate=self.discounting_rate,
-            )
+    def _stochastic_reward_process(self) -> RenewalRewardProcess:
         return RenewalRewardProcess(
             self.baseline_model,
             RunToFailureReward(self.cf),
             discounting_rate=self.discounting_rate,
-            first_lifetime_model=LeftTruncatedModel(self.baseline_model).freeze(
-                self.a0
-            ),
-        )
+            )
 
     def expected_net_present_value(
-        self, tf: float, nb_steps: int, total_sum: bool = False
+        self, tf: float, nb_steps: int, total_sum: bool = False, a0: NumpyFloat | None = None,
     ) -> tuple[NDArray[np.float64], NDArray[np.float64]]:
-        timeline, npv = self._stochastic_process.expected_total_reward(tf, nb_steps)
+        timeline, npv = self._stochastic_reward_process.expected_total_reward(tf, nb_steps, a0=a0)
         if total_sum and npv.ndim == 2:
             npv = np.sum(npv, axis=0)
         return timeline, npv
 
     @overload
     def asymptotic_expected_net_present_value(
-        self, total_sum: Literal[False]
+        self, total_sum: Literal[False], a0: NumpyFloat | None = None,
     ) -> NDArray[np.float64]: ...
     @overload
     def asymptotic_expected_net_present_value(
-        self, total_sum: Literal[True]
+        self, total_sum: Literal[True], a0: NumpyFloat | None = None,
     ) -> np.float64: ...
     @overload
     def asymptotic_expected_net_present_value(
-        self, total_sum: bool = False
+        self, total_sum: bool = False, a0: NumpyFloat | None = None,
     ) -> np.float64 | NDArray[np.float64]: ...
     def asymptotic_expected_net_present_value(
-        self, total_sum: bool = False
+        self, total_sum: bool = False, a0: NumpyFloat | None = None,
     ) -> np.float64 | NDArray[np.float64]:
-        asymptotic_npv = self._stochastic_process.asymptotic_expected_total_reward()
+        asymptotic_npv = self._stochastic_reward_process.asymptotic_expected_total_reward(a0=a0)
         if total_sum:
             return np.sum(asymptotic_npv)
         return asymptotic_npv
 
     def expected_equivalent_annual_cost(
-        self, tf: float, nb_steps: int, total_sum: bool = False
+        self, tf: float, nb_steps: int, total_sum: bool = False, a0: NumpyFloat | None = None,
     ) -> tuple[NDArray[np.float64], NDArray[np.float64]]:
-        timeline, eeac = self._stochastic_process.expected_equivalent_annual_worth(
-            tf, nb_steps
+        timeline, eeac = self._stochastic_reward_process.expected_equivalent_annual_worth(
+            tf, nb_steps, a0=a0
         )
         if total_sum and eeac.ndim == 2:
             eeac = np.sum(eeac, axis=0)
@@ -306,43 +297,48 @@ class RunToFailurePolicy(BaseRunToFailure):
 
     @overload
     def asymptotic_expected_equivalent_annual_cost(
-        self, total_sum: Literal[False]
+        self, total_sum: Literal[False], a0: NumpyFloat | None = None,
     ) -> NDArray[np.float64]: ...
     @overload
     def asymptotic_expected_equivalent_annual_cost(
-        self, total_sum: Literal[True]
+        self, total_sum: Literal[True], a0: NumpyFloat | None = None,
     ) -> np.float64: ...
     @overload
     def asymptotic_expected_equivalent_annual_cost(
-        self, total_sum: bool = False
+        self, total_sum: bool = False, a0: NumpyFloat | None = None,
     ) -> np.float64 | NDArray[np.float64]: ...
     def asymptotic_expected_equivalent_annual_cost(
-        self, total_sum: bool = False
+        self, total_sum: bool = False, a0: NumpyFloat | None = None,
     ) -> np.float64 | NDArray[np.float64]:
         asymptotic_eeac = (
-            self._stochastic_process.asymptotic_expected_equivalent_annual_worth()
+            self._stochastic_reward_process.asymptotic_expected_equivalent_annual_worth(a0=a0)
         )
         if total_sum:
             return np.sum(asymptotic_eeac)
         return asymptotic_eeac
 
-    def sample(self, size, tf, t0=0.0, seed=None):
+    def sample(
+        self,
+        nb_samples: int,
+        time_window: tuple[float, float],
+        a0: NumpyFloat | None = None,
+        seed=None,
+    ):
         """Renewal data sampling.
 
         This function will sample data and encapsulate them in an object.
 
         Parameters
         ----------
-        size : int
-            The size of the desired sample.
-        tf : float
-            Time at the end of the observation.
-        t0 : float, default 0
-            Time at the beginning of the observation.
-        size : int or tuple of 2 int
-            Size of the sample
+        nb_samples : int
+            The number of samples.
+        time_window : tuple of two floats
+            Time window in which data are sampled.
         seed : int, optional
             Random seed, by default None.
 
         """
-        return self._stochastic_process.sample(tf, t0, size, seed)
+
+        return self._stochastic_reward_process.sample(
+            nb_samples, time_window, a0=a0, seed=seed
+        )

--- a/src/relife/policy/_run_to_failure.py
+++ b/src/relife/policy/_run_to_failure.py
@@ -8,9 +8,6 @@ import numpy as np
 from numpy.typing import NDArray
 
 from relife.economic import RunToFailureReward
-from relife.lifetime_model import (
-    LeftTruncatedModel,
-)
 from relife.stochastic_process import RenewalRewardProcess
 from relife.typing import (
     AnyFloat,
@@ -255,41 +252,63 @@ class RunToFailurePolicy(BaseRunToFailure):
             self.baseline_model,
             RunToFailureReward(self.cf),
             discounting_rate=self.discounting_rate,
-            )
+        )
 
     def expected_net_present_value(
-        self, tf: float, nb_steps: int, total_sum: bool = False, a0: NumpyFloat | None = None,
+        self,
+        tf: float,
+        nb_steps: int,
+        total_sum: bool = False,
+        a0: NumpyFloat | None = None,
     ) -> tuple[NDArray[np.float64], NDArray[np.float64]]:
-        timeline, npv = self._stochastic_reward_process.expected_total_reward(tf, nb_steps, a0=a0)
+        timeline, npv = self._stochastic_reward_process.expected_total_reward(
+            tf, nb_steps, a0=a0
+        )
         if total_sum and npv.ndim == 2:
             npv = np.sum(npv, axis=0)
         return timeline, npv
 
     @overload
     def asymptotic_expected_net_present_value(
-        self, total_sum: Literal[False], a0: NumpyFloat | None = None,
+        self,
+        total_sum: Literal[False],
+        a0: NumpyFloat | None = None,
     ) -> NDArray[np.float64]: ...
     @overload
     def asymptotic_expected_net_present_value(
-        self, total_sum: Literal[True], a0: NumpyFloat | None = None,
+        self,
+        total_sum: Literal[True],
+        a0: NumpyFloat | None = None,
     ) -> np.float64: ...
     @overload
     def asymptotic_expected_net_present_value(
-        self, total_sum: bool = False, a0: NumpyFloat | None = None,
+        self,
+        total_sum: bool = False,
+        a0: NumpyFloat | None = None,
     ) -> np.float64 | NDArray[np.float64]: ...
     def asymptotic_expected_net_present_value(
-        self, total_sum: bool = False, a0: NumpyFloat | None = None,
+        self,
+        total_sum: bool = False,
+        a0: NumpyFloat | None = None,
     ) -> np.float64 | NDArray[np.float64]:
-        asymptotic_npv = self._stochastic_reward_process.asymptotic_expected_total_reward(a0=a0)
+        asymptotic_npv = (
+            self._stochastic_reward_process.asymptotic_expected_total_reward(a0=a0)
+        )
         if total_sum:
             return np.sum(asymptotic_npv)
         return asymptotic_npv
 
     def expected_equivalent_annual_cost(
-        self, tf: float, nb_steps: int, total_sum: bool = False, a0: NumpyFloat | None = None,
+        self,
+        tf: float,
+        nb_steps: int,
+        total_sum: bool = False,
+        a0: NumpyFloat | None = None,
     ) -> tuple[NDArray[np.float64], NDArray[np.float64]]:
-        timeline, eeac = self._stochastic_reward_process.expected_equivalent_annual_worth(
-            tf, nb_steps, a0=a0
+        timeline, eeac = (
+            self._stochastic_reward_process.expected_equivalent_annual_worth(
+                tf, nb_steps, a0=a0
+            )
         )
         if total_sum and eeac.ndim == 2:
             eeac = np.sum(eeac, axis=0)
@@ -297,21 +316,31 @@ class RunToFailurePolicy(BaseRunToFailure):
 
     @overload
     def asymptotic_expected_equivalent_annual_cost(
-        self, total_sum: Literal[False], a0: NumpyFloat | None = None,
+        self,
+        total_sum: Literal[False],
+        a0: NumpyFloat | None = None,
     ) -> NDArray[np.float64]: ...
     @overload
     def asymptotic_expected_equivalent_annual_cost(
-        self, total_sum: Literal[True], a0: NumpyFloat | None = None,
+        self,
+        total_sum: Literal[True],
+        a0: NumpyFloat | None = None,
     ) -> np.float64: ...
     @overload
     def asymptotic_expected_equivalent_annual_cost(
-        self, total_sum: bool = False, a0: NumpyFloat | None = None,
+        self,
+        total_sum: bool = False,
+        a0: NumpyFloat | None = None,
     ) -> np.float64 | NDArray[np.float64]: ...
     def asymptotic_expected_equivalent_annual_cost(
-        self, total_sum: bool = False, a0: NumpyFloat | None = None,
+        self,
+        total_sum: bool = False,
+        a0: NumpyFloat | None = None,
     ) -> np.float64 | NDArray[np.float64]:
         asymptotic_eeac = (
-            self._stochastic_reward_process.asymptotic_expected_equivalent_annual_worth(a0=a0)
+            self._stochastic_reward_process.asymptotic_expected_equivalent_annual_worth(
+                a0=a0
+            )
         )
         if total_sum:
             return np.sum(asymptotic_eeac)

--- a/src/relife/policy/_run_to_failure.py
+++ b/src/relife/policy/_run_to_failure.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from abc import ABC
-from typing import Any, Literal, Optional, overload
+from typing import Any, Literal, overload
 
 import numpy as np
 from numpy.typing import NDArray
@@ -80,7 +80,6 @@ def run_to_failure_policy(
 
 class BaseRunToFailure(ReplacementPolicy[AnyParametricLifetimeModel[()]], ABC):
     _cost_structure: dict[str, NumpyFloat]
-    _a0: Optional[NumpyFloat]
     discounting_rate: float
 
     def __init__(
@@ -88,27 +87,12 @@ class BaseRunToFailure(ReplacementPolicy[AnyParametricLifetimeModel[()]], ABC):
         lifetime_model: AnyParametricLifetimeModel[()],
         cf: AnyFloat,
         discounting_rate: float = 0.0,
-        a0: Optional[AnyFloat] = None,
     ):
         super().__init__(
             lifetime_model,
             {"cf": reshape_1d_arg(cf)},
             discounting_rate=discounting_rate,
         )
-        self._a0 = reshape_1d_arg(a0) if a0 is not None else a0
-
-    @property
-    def a0(self) -> Optional[NumpyFloat]:
-        """Current ages of the assets.
-
-        Returns
-        -------
-        np.ndarray
-        """
-        # _a0 is (m, 1) but exposed cf is (m,)
-        if self._a0 is None:
-            return self._a0
-        return flatten_if_possible(self._a0)
 
     @property
     def cf(self) -> NumpyFloat:
@@ -158,87 +142,83 @@ class OneCycleRunToFailurePolicy(BaseRunToFailure):
         lifetime_model: AnyParametricLifetimeModel[()],
         cf: AnyFloat,
         discounting_rate: float = 0.0,
-        a0: Optional[AnyFloat] = None,
         period_before_discounting: float = 1.0,
     ) -> None:
-        super().__init__(lifetime_model, cf, discounting_rate=discounting_rate, a0=a0)
+        super().__init__(lifetime_model, cf, discounting_rate=discounting_rate)
         self.period_before_discounting = period_before_discounting
 
     @property
     def _expected_costs(self) -> OneCycleExpectedCosts:
-        if self.a0 is None:
-            return OneCycleExpectedCosts(
-                self.baseline_model,
-                RunToFailureReward(self.cf),
-                discounting_rate=self.discounting_rate,
-                period_before_discounting=self.period_before_discounting,
-            )
         return OneCycleExpectedCosts(
-            LeftTruncatedModel(self.baseline_model).freeze(self.a0),
+            self.baseline_model,
             RunToFailureReward(self.cf),
             discounting_rate=self.discounting_rate,
             period_before_discounting=self.period_before_discounting,
         )
 
     def expected_net_present_value(
-        self, tf: float, nb_steps: int, total_sum: bool = False
+        self,
+        tf: float,
+        nb_steps: int,
+        total_sum: bool = False,
+        a0: NumpyFloat | None = None,
     ) -> tuple[NDArray[np.float64], NDArray[np.float64]]:
-        timeline, npv = self._expected_costs.expected_net_present_value(tf, nb_steps)
+        timeline, npv = self._expected_costs.expected_net_present_value(
+            tf, nb_steps, a0=a0
+        )
         if total_sum and npv.ndim == 2:
             return timeline, np.sum(npv, axis=0)
         return timeline, npv
 
     @overload
     def asymptotic_expected_net_present_value(
-        self, total_sum: Literal[False]
+        self, total_sum: Literal[False], a0: NumpyFloat | None = None
     ) -> NDArray[np.float64]: ...
     @overload
     def asymptotic_expected_net_present_value(
-        self, total_sum: Literal[True]
+        self, total_sum: Literal[True], a0: NumpyFloat | None = None
     ) -> np.float64: ...
     @overload
     def asymptotic_expected_net_present_value(
-        self, total_sum: bool = False
+        self, total_sum: bool = False, a0: NumpyFloat | None = None
     ) -> np.float64 | NDArray[np.float64]: ...
     def asymptotic_expected_net_present_value(
-        self, total_sum: bool = False
+        self, total_sum: bool = False, a0: NumpyFloat | None = None
     ) -> np.float64 | NDArray[np.float64]:
-        asymptotic_npv = self._expected_costs.asymptotic_expected_net_present_value()
-        if total_sum:
-            return np.sum(asymptotic_npv)
-        return asymptotic_npv
+        return self._expected_costs.asymptotic_expected_net_present_value(
+            total_sum, a0=a0
+        )
 
     def expected_equivalent_annual_cost(
-        self, tf: float, nb_steps: int, total_sum: bool = False
+        self,
+        tf: float,
+        nb_steps: int,
+        total_sum: bool = False,
+        a0: NumpyFloat | None = None,
     ) -> tuple[NDArray[np.float64], NDArray[np.float64]]:
         timeline, eeac = self._expected_costs.expected_equivalent_annual_cost(
-            tf, nb_steps
+            tf, nb_steps, total_sum=total_sum, a0=a0
         )
-        if total_sum and eeac.ndim == 2:
-            return timeline, np.sum(eeac, axis=0)
         return timeline, eeac
 
     @overload
     def asymptotic_expected_equivalent_annual_cost(
-        self, total_sum: Literal[False]
+        self, total_sum: Literal[False], a0: NumpyFloat | None = None
     ) -> NDArray[np.float64]: ...
     @overload
     def asymptotic_expected_equivalent_annual_cost(
-        self, total_sum: Literal[True]
+        self, total_sum: Literal[True], a0: NumpyFloat | None = None
     ) -> np.float64: ...
     @overload
     def asymptotic_expected_equivalent_annual_cost(
-        self, total_sum: bool = False
+        self, total_sum: bool = False, a0: NumpyFloat | None = None
     ) -> np.float64 | NDArray[np.float64]: ...
     def asymptotic_expected_equivalent_annual_cost(
-        self, total_sum: bool = False
+        self, total_sum: bool = False, a0: NumpyFloat | None = None
     ) -> np.float64 | NDArray[np.float64]:
-        asymptotic_eeac = (
-            self._expected_costs.asymptotic_expected_equivalent_annual_cost()
+        return self._expected_costs.asymptotic_expected_equivalent_annual_cost(
+            total_sum=total_sum, a0=a0
         )
-        if total_sum:
-            return np.sum(asymptotic_eeac)
-        return asymptotic_eeac
 
 
 class RunToFailurePolicy(BaseRunToFailure):

--- a/src/relife/policy/_run_to_failure.py
+++ b/src/relife/policy/_run_to_failure.py
@@ -125,9 +125,6 @@ class OneCycleRunToFailurePolicy(BaseRunToFailure):
         Costs of failures
     discounting_rate : float, default is 0.
         The discounting rate value used in the exponential discounting function
-    a0 : float or 1darray, optional
-        Current ages of the assets, by default 0 for each asset. If it is given, left truncations of ``a0`` will
-        be take into account for the first cycle.
 
     Attributes
     ----------
@@ -231,9 +228,6 @@ class RunToFailurePolicy(BaseRunToFailure):
         Costs of failures
     discounting_rate : float, default is 0.
         The discounting rate value used in the exponential discounting function
-    a0 : float or 1darray, optional
-        Current ages of the assets, by default 0 for each asset. If it is given, left truncations of ``a0`` will
-        be take into account for the first cycle.
 
     Attributes
     ----------
@@ -365,6 +359,8 @@ class RunToFailurePolicy(BaseRunToFailure):
             Time window in which data are sampled.
         seed : int, optional
             Random seed, by default None.
+        a0 : float or np.ndarray or None
+            Optional, initial ages
 
         """
 

--- a/src/relife/policy/tests/test_age_replacement_policy.py
+++ b/src/relife/policy/tests/test_age_replacement_policy.py
@@ -20,10 +20,10 @@ class TestOneCycleAgeReplacementPolicy:
             distribution, cf, cp, discounting_rate=discounting_rate
         )
         try:
-            policy.compute_optimal_ar()
+            ar = policy.compute_optimal_ar()
         except RuntimeError:
             pytest.skip("Optimization failed, EEAC may be too flat")
-        qa = policy.asymptotic_expected_equivalent_annual_cost()
+        qa = policy.asymptotic_expected_equivalent_annual_cost(ar)
         assert qa.shape == np.broadcast_shapes(cf.shape, cp.shape)  # () or (m,)
 
     # ignore runtime warning in optimization
@@ -39,12 +39,12 @@ class TestOneCycleAgeReplacementPolicy:
             distribution, cf, cp, discounting_rate=discounting_rate
         )
         try:
-            policy.compute_optimal_ar()
+            ar = policy.compute_optimal_ar()
         except RuntimeError:
             pytest.skip("Optimization failed, EEAC may be too flat")
 
-        qa = policy.asymptotic_expected_equivalent_annual_cost()  # () or (m,)
-        timeline, q = policy.expected_equivalent_annual_cost(400, nb_steps=2000)
+        qa = policy.asymptotic_expected_equivalent_annual_cost(ar)  # () or (m,)
+        timeline, q = policy.expected_equivalent_annual_cost(ar, 400, nb_steps=2000)
 
         assert timeline.shape == (2000,)
         assert q.shape == qa.shape + timeline.shape  # (m, 2000) or (2000,)
@@ -57,29 +57,14 @@ class TestOneCycleAgeReplacementPolicy:
         eps = 1e-2
         policy = OneCycleAgeReplacementPolicy(
             distribution, cf, cp, discounting_rate=discounting_rate
-        ).compute_optimal_ar()
-        suboptimal_policy1 = OneCycleAgeReplacementPolicy(
-            distribution,
-            cf,
-            cp,
-            discounting_rate=discounting_rate,
-            period_before_discounting=0.1,
-            ar=policy.ar + eps,
         )
-        suboptimal_policy2 = OneCycleAgeReplacementPolicy(
-            distribution,
-            cf,
-            cp,
-            discounting_rate=discounting_rate,
-            period_before_discounting=0.1,
-            ar=policy.ar - eps,
-        )
+        ar = policy.compute_optimal_ar()
         assert np.all(
-            suboptimal_policy1.asymptotic_expected_equivalent_annual_cost()
-            > policy.asymptotic_expected_equivalent_annual_cost()
+            policy.asymptotic_expected_equivalent_annual_cost(ar+eps)
+            > policy.asymptotic_expected_equivalent_annual_cost(ar)
         ) and np.all(
-            suboptimal_policy2.asymptotic_expected_equivalent_annual_cost()
-            > policy.asymptotic_expected_equivalent_annual_cost()
+            policy.asymptotic_expected_equivalent_annual_cost(ar-eps)
+            > policy.asymptotic_expected_equivalent_annual_cost(ar)
         )
 
 
@@ -97,10 +82,10 @@ class TestAgeReplacementPolicy:
             distribution, cf, cp, discounting_rate=discounting_rate
         )
         try:
-            policy.compute_optimal_ar()
+            ar = policy.compute_optimal_ar()
         except RuntimeError:
             pytest.skip("Optimization failed, EEAC may be too flat")
-        qa = policy.asymptotic_expected_equivalent_annual_cost()  # () or (m,)
+        qa = policy.asymptotic_expected_equivalent_annual_cost(ar)  # () or (m,)
         assert qa.shape == np.broadcast_shapes(cf.shape, cp.shape)  # () or (m,)
 
     @pytest.mark.filterwarnings("ignore::RuntimeWarning")
@@ -115,11 +100,11 @@ class TestAgeReplacementPolicy:
             distribution, cf, cp, discounting_rate=discounting_rate
         )
         try:
-            policy.compute_optimal_ar()
+            ar = policy.compute_optimal_ar()
         except RuntimeError:
             pytest.skip("Optimization failed, EEAC may be too flat")
-        qa = policy.asymptotic_expected_equivalent_annual_cost()  # () or (m,)
-        timeline, q = policy.expected_equivalent_annual_cost(400, nb_steps=2000)
+        qa = policy.asymptotic_expected_equivalent_annual_cost(ar)  # () or (m,)
+        timeline, q = policy.expected_equivalent_annual_cost(ar, 400, nb_steps=2000)
 
         assert timeline.shape == (2000,)
         assert q.shape == qa.shape + timeline.shape  # (m, 2000) or (2000,)
@@ -133,18 +118,12 @@ class TestAgeReplacementPolicy:
         eps = 1e-2
         policy = AgeReplacementPolicy(
             distribution, cf, cp, discounting_rate=discounting_rate
-        ).compute_optimal_ar()
-        suboptimal_policy1 = AgeReplacementPolicy(
-            distribution, cf, cp, discounting_rate=discounting_rate, ar=policy.ar + eps
         )
-        suboptimal_policy2 = AgeReplacementPolicy(
-            distribution, cf, cp, discounting_rate=discounting_rate, ar=policy.ar - eps
-        )
-
+        ar = policy.compute_optimal_ar()
         assert np.all(
-            suboptimal_policy1.asymptotic_expected_equivalent_annual_cost()
-            > policy.asymptotic_expected_equivalent_annual_cost()
+            policy.asymptotic_expected_equivalent_annual_cost(ar+eps)
+            > policy.asymptotic_expected_equivalent_annual_cost(ar)
         ) and np.all(
-            suboptimal_policy2.asymptotic_expected_equivalent_annual_cost()
-            > policy.asymptotic_expected_equivalent_annual_cost()
+            policy.asymptotic_expected_equivalent_annual_cost(ar-eps)
+            > policy.asymptotic_expected_equivalent_annual_cost(ar)
         )

--- a/src/relife/policy/tests/test_age_replacement_policy.py
+++ b/src/relife/policy/tests/test_age_replacement_policy.py
@@ -20,7 +20,7 @@ class TestOneCycleAgeReplacementPolicy:
             distribution, cf, cp, discounting_rate=discounting_rate
         )
         try:
-            policy.optimize()
+            policy.compute_optimal_ar()
         except RuntimeError:
             pytest.skip("Optimization failed, EEAC may be too flat")
         qa = policy.asymptotic_expected_equivalent_annual_cost()
@@ -39,7 +39,7 @@ class TestOneCycleAgeReplacementPolicy:
             distribution, cf, cp, discounting_rate=discounting_rate
         )
         try:
-            policy.optimize()
+            policy.compute_optimal_ar()
         except RuntimeError:
             pytest.skip("Optimization failed, EEAC may be too flat")
 
@@ -57,7 +57,7 @@ class TestOneCycleAgeReplacementPolicy:
         eps = 1e-2
         policy = OneCycleAgeReplacementPolicy(
             distribution, cf, cp, discounting_rate=discounting_rate
-        ).optimize()
+        ).compute_optimal_ar()
         suboptimal_policy1 = OneCycleAgeReplacementPolicy(
             distribution,
             cf,
@@ -97,7 +97,7 @@ class TestAgeReplacementPolicy:
             distribution, cf, cp, discounting_rate=discounting_rate
         )
         try:
-            policy.optimize()
+            policy.compute_optimal_ar()
         except RuntimeError:
             pytest.skip("Optimization failed, EEAC may be too flat")
         qa = policy.asymptotic_expected_equivalent_annual_cost()  # () or (m,)
@@ -115,7 +115,7 @@ class TestAgeReplacementPolicy:
             distribution, cf, cp, discounting_rate=discounting_rate
         )
         try:
-            policy.optimize()
+            policy.compute_optimal_ar()
         except RuntimeError:
             pytest.skip("Optimization failed, EEAC may be too flat")
         qa = policy.asymptotic_expected_equivalent_annual_cost()  # () or (m,)
@@ -133,7 +133,7 @@ class TestAgeReplacementPolicy:
         eps = 1e-2
         policy = AgeReplacementPolicy(
             distribution, cf, cp, discounting_rate=discounting_rate
-        ).optimize()
+        ).compute_optimal_ar()
         suboptimal_policy1 = AgeReplacementPolicy(
             distribution, cf, cp, discounting_rate=discounting_rate, ar=policy.ar + eps
         )

--- a/src/relife/stochastic_process/_sample/_iterators.py
+++ b/src/relife/stochastic_process/_sample/_iterators.py
@@ -42,9 +42,7 @@ def _expand_lifetime_model(
         broadcasted_args = list(
             np.repeat(arg, nb_samples, axis=0) for arg in lifetime_model.args
         )
-        expanded_lifetime_model = lifetime_model.unfreeze().freeze(
-            *broadcasted_args
-        )
+        expanded_lifetime_model = lifetime_model.unfreeze().freeze(*broadcasted_args)
 
     return expanded_lifetime_model
 
@@ -342,8 +340,8 @@ class RenewalProcessIterator(StochasticDataIterator):
             nb_assets=nb_assets,
             seed=seed,
         )
-        first_lifetime_model = (
-            _expand_lifetime_model(self.process.first_lifetime_model, nb_samples)
+        first_lifetime_model = _expand_lifetime_model(
+            self.process.first_lifetime_model, nb_samples
         )
         self._expanded_first_lifetime_model = LeftTruncatedModel(
             first_lifetime_model

--- a/src/relife/stochastic_process/_sample/_iterators.py
+++ b/src/relife/stochastic_process/_sample/_iterators.py
@@ -344,8 +344,6 @@ class RenewalProcessIterator(StochasticDataIterator):
         )
         first_lifetime_model = (
             _expand_lifetime_model(self.process.first_lifetime_model, nb_samples)
-            if self.process.first_lifetime_model is not None
-            else self._expanded_lifetime_model
         )
         self._expanded_first_lifetime_model = LeftTruncatedModel(
             first_lifetime_model

--- a/src/relife/stochastic_process/renewal_process.py
+++ b/src/relife/stochastic_process/renewal_process.py
@@ -373,8 +373,8 @@ class RenewalRewardProcess(RenewalProcess):
         # TODO: comprendre le delayed solver ici
         z = renewal_equation_solver(
             timeline,
-            self.first_lifetime_model,
-            lambda t: self.first_lifetime_model.ls_integrate(
+            self.lifetime_model,
+            lambda t: self.lifetime_model.ls_integrate(
                 lambda x: (
                     self.reward.conditional_expectation(x) * self.discounting.factor(x)
                 ),
@@ -384,22 +384,21 @@ class RenewalRewardProcess(RenewalProcess):
             ),  # reward partial expectation
             discounting=self.discounting,
         )
-        if self.first_lifetime_model is not None:
-            z = delayed_renewal_equation_solver(
-                timeline,
-                z,
-                self.first_lifetime_model,
-                lambda t: self.first_lifetime_model.ls_integrate(
-                    lambda x: (
-                        self.first_reward.conditional_expectation(x)
-                        * self.discounting.factor(x)
-                    ),
-                    np.zeros_like(t),
-                    np.asarray(t),
-                    deg=15,
-                ),  # reward partial expectation
-                discounting=self.discounting,
-            )
+        z = delayed_renewal_equation_solver(
+            timeline,
+            z,
+            self.first_lifetime_model,
+            lambda t: self.first_lifetime_model.ls_integrate(
+                lambda x: (
+                    self.first_reward.conditional_expectation(x)
+                    * self.discounting.factor(x)
+                ),
+                np.zeros_like(t),
+                np.asarray(t),
+                deg=15,
+            ),  # reward partial expectation
+            discounting=self.discounting,
+        )
         return np.squeeze(timeline), np.squeeze(
             z
         )  # (nb_steps,), (nb_steps,) or (m, nb_steps)

--- a/src/relife/stochastic_process/renewal_process.py
+++ b/src/relife/stochastic_process/renewal_process.py
@@ -162,6 +162,9 @@ class RenewalProcess(ParametricModel):
         a0: NumpyFloat | None = None,
         ar: NumpyFloat | None = None,
     ) -> tuple[NDArray[np.float64], NDArray[np.float64]]:
+        
+        ar_assign = ar if ar is not None else np.inf
+        a0_assign = a0 if a0 is not None else 0
 
         timeline = _make_timeline(tf, nb_steps)  # (nb_steps,) or (1, nb_steps)
 
@@ -172,14 +175,14 @@ class RenewalProcess(ParametricModel):
             timeline,
             lifetime_model_applied,
             lambda t: (
-                (1 - self.lifetime_model.cdf(ar or np.inf)) * (t > (ar or np.inf))
+                (1 - self.lifetime_model.cdf(ar_assign)) * (t > (ar_assign))
             ),
         )
 
         first_lifetime_model_applied = get_conditional_lifetime_model(
             self.first_lifetime_model, a0=a0, ar=ar
         )
-        first_ar = (ar or np.inf) - (a0 or 0)
+        first_ar = (ar_assign) - (a0_assign)
         delayed_evaluated_func = lambda t: (
             (
                 1
@@ -464,10 +467,10 @@ class RenewalRewardProcess(RenewalProcess):
         z = renewal_equation_solver(
             timeline,
             lifetime_model_applied,
-            lambda t: self.lifetime_model.ls_integrate(
+            lambda t: lifetime_model_applied.ls_integrate(
                 lambda x: (
                     self.reward.conditional_expectation(x)
-                    * self.discounting.factor(apply_bias(x, censor_value=ar))
+                    * self.discounting.factor(x)
                 ),
                 np.zeros_like(t),
                 np.asarray(t),
@@ -479,15 +482,11 @@ class RenewalRewardProcess(RenewalProcess):
         first_lifetime_model_applied = get_conditional_lifetime_model(
             self.first_lifetime_model, a0=a0, ar=ar
         )
-        delayed_evaluated_func = lambda t: get_conditional_lifetime_model(
-                self.first_lifetime_model, a0=a0
-            ).ls_integrate(
+        delayed_evaluated_func = lambda t: first_lifetime_model_applied.ls_integrate(
                 lambda x: (
-                    self.first_reward.conditional_expectation(apply_bias(x, delay=a0))
+                    self.first_reward.conditional_expectation(apply_bias(x,delay=a0))
                     * self.discounting.factor(
-                        apply_bias(
-                            x, censor_value=ar, delay=a0, delay_applied_to_censor=True
-                        )
+                        x
                     )
                 ),
                 np.zeros_like(t),
@@ -552,9 +551,9 @@ class RenewalRewardProcess(RenewalProcess):
         )  # () or (m, 1)
         if self.discounting_rate == 0.0:
             return np.full_like(np.squeeze(lf), np.inf)
-        ly = self.lifetime_model.ls_integrate(
+        ly = lifetime_model_applied.ls_integrate(
             lambda x: (
-                self.discounting.factor(apply_bias(x, censor_value=ar))
+                self.discounting.factor(x)
                 * self.reward.conditional_expectation(x)
             ),
             0.0,
@@ -572,16 +571,12 @@ class RenewalRewardProcess(RenewalProcess):
             )
         )  # () or (m,)
         ly1 = np.squeeze(
-            get_conditional_lifetime_model(
-                self.first_lifetime_model, a0=a0
-            ).ls_integrate(
+            first_lifetime_model_applied.ls_integrate(
                 lambda x: (
                     self.discounting.factor(
-                        apply_bias(
-                            x, censor_value=ar, delay=a0, delay_applied_to_censor=True
-                        )
+                        x
                     )
-                    * self.first_reward.conditional_expectation(x)
+                    * self.first_reward.conditional_expectation(apply_bias(x,delay=a0))
                 ),
                 0.0,
                 np.inf,
@@ -645,14 +640,13 @@ class RenewalRewardProcess(RenewalProcess):
         ndarray
             The assymptotic expected equivalent annual worth.
         """
-
-        lifetime_model_applied = get_conditional_lifetime_model(
-            self.lifetime_model, ar=ar
-        )
         if self.discounting_rate == 0.0:
+            lifetime_model_applied = get_conditional_lifetime_model(
+                self.lifetime_model, ar=ar
+            )
             return np.squeeze(
                 np.asarray(
-                    self.lifetime_model.ls_integrate(
+                    lifetime_model_applied.ls_integrate(
                         lambda x: self.reward.conditional_expectation(x),
                         np.float64(0.0),
                         np.asarray(np.inf),

--- a/src/relife/stochastic_process/renewal_process.py
+++ b/src/relife/stochastic_process/renewal_process.py
@@ -428,7 +428,7 @@ class RenewalRewardProcess(RenewalProcess):
         z = renewal_equation_solver(
             timeline,
             lifetime_model_applied,
-            lambda t: lifetime_model_applied.ls_integrate(
+            lambda t: self.lifetime_model.ls_integrate(
                 lambda x: (
                     self.reward.conditional_expectation(x) * self.discounting.factor(x)
                 ),
@@ -439,20 +439,22 @@ class RenewalRewardProcess(RenewalProcess):
             discounting=self.discounting,
         )
 
+
         first_lifetime_model_applied = get_conditional_lifetime_model(self.first_lifetime_model,a0=a0, ar=ar)
-        z = delayed_renewal_equation_solver(
-            timeline,
-            z,
-            first_lifetime_model_applied,
-            lambda t: first_lifetime_model_applied.ls_integrate(
+        delayed_evaluated_func = lambda t: get_conditional_lifetime_model(self.first_lifetime_model, a0=a0).ls_integrate(
                 lambda x: (
-                    self.first_reward.conditional_expectation(x)
-                    * self.discounting.factor(x)
+                    self.first_reward.conditional_expectation(x + (a0 or 0)) * self.discounting.factor(x + (a0 or 0))
                 ),
                 np.zeros_like(t),
                 np.asarray(t),
                 deg=15,
             ),  # reward partial expectation
+        
+        z = delayed_renewal_equation_solver(
+            timeline,
+            z,
+            first_lifetime_model_applied,
+            delayed_evaluated_func,
             discounting=self.discounting,
         )
         return np.squeeze(timeline), np.squeeze(
@@ -501,7 +503,7 @@ class RenewalRewardProcess(RenewalProcess):
         )  # () or (m, 1)
         if self.discounting_rate == 0.0:
             return np.full_like(np.squeeze(lf), np.inf)
-        ly = lifetime_model_applied.ls_integrate(
+        ly = self.lifetime_model.ls_integrate(
             lambda x: (
                 self.discounting.factor(x) * self.reward.conditional_expectation(x)
             ),
@@ -518,10 +520,10 @@ class RenewalRewardProcess(RenewalProcess):
             )
         )  # () or (m,)
         ly1 = np.squeeze(
-                first_lifetime_model_applied.ls_integrate(
+                get_conditional_lifetime_model(self.first_lifetime_model,a0=a0).ls_integrate(
                 lambda x: (
-                    self.discounting.factor(x)
-                    * self.first_reward.conditional_expectation(x)
+                    self.discounting.factor(x + (a0 or 0))
+                    * self.first_reward.conditional_expectation(x + (a0 or 0))
                 ),
                 0.0,
                 np.inf,
@@ -586,7 +588,7 @@ class RenewalRewardProcess(RenewalProcess):
         if self.discounting_rate == 0.0:
             return np.squeeze(
                 np.asarray(
-                    lifetime_model_applied.ls_integrate(
+                    self.lifetime_model.ls_integrate(
                         lambda x: self.reward.conditional_expectation(x),
                         np.float64(0.0),
                         np.asarray(np.inf),

--- a/src/relife/stochastic_process/renewal_process.py
+++ b/src/relife/stochastic_process/renewal_process.py
@@ -8,13 +8,9 @@ from numpy.typing import NDArray
 
 from relife.base import ParametricModel
 from relife.economic import ExponentialDiscounting, Reward
-from relife.lifetime_model import (
-    LeftTruncatedModel,
-)
 from relife.stochastic_process._sample import StochasticSampleMapping
 from relife.typing import AnyParametricLifetimeModel
 from relife.typing._scalars import NumpyFloat
-from relife.utils import get_model_nb_assets
 
 from ._renewal_equations import (
     delayed_renewal_equation_solver,
@@ -115,9 +111,7 @@ class RenewalProcess(ParametricModel):
 
         timeline = _make_timeline(tf, nb_steps)  # (nb_steps,) or (1, nb_steps)
         renewal_function = renewal_equation_solver(
-            timeline,
-            self.lifetime_model,
-            self.first_lifetime_model.cdf
+            timeline, self.lifetime_model, self.first_lifetime_model.cdf
         )
         return np.squeeze(timeline), np.squeeze(renewal_function)
 
@@ -162,9 +156,7 @@ class RenewalProcess(ParametricModel):
         """
         timeline = _make_timeline(tf, nb_steps)  #  (nb_steps,) or (m, nb_steps)
         renewal_density = renewal_equation_solver(
-            timeline,
-            self.lifetime_model,
-            self.first_lifetime_model.pdf
+            timeline, self.lifetime_model, self.first_lifetime_model.pdf
         )
         return np.squeeze(timeline), np.squeeze(renewal_density)
 
@@ -230,13 +222,10 @@ class RenewalProcess(ParametricModel):
         A dict of time, event, entry and args (covariates)
 
         """
-        from relife.base import FrozenParametricModel
 
         from ._sample import RenewalProcessIterable
 
-        if (
-            self.first_lifetime_model != self.lifetime_model
-        ):
+        if self.first_lifetime_model != self.lifetime_model:
             raise ValueError(
                 "Calling sample_lifetime_data with lifetime_model different from first_lifetime_model is ambiguous."
             )

--- a/src/relife/stochastic_process/renewal_process.py
+++ b/src/relife/stochastic_process/renewal_process.py
@@ -162,7 +162,7 @@ class RenewalProcess(ParametricModel):
         a0: NumpyFloat | None = None,
         ar: NumpyFloat | None = None,
     ) -> tuple[NDArray[np.float64], NDArray[np.float64]]:
-        
+
         ar_assign = ar if ar is not None else np.inf
         a0_assign = a0 if a0 is not None else 0
 
@@ -174,9 +174,7 @@ class RenewalProcess(ParametricModel):
         z = renewal_equation_solver(
             timeline,
             lifetime_model_applied,
-            lambda t: (
-                (1 - self.lifetime_model.cdf(ar_assign)) * (t > (ar_assign))
-            ),
+            lambda t: (1 - self.lifetime_model.cdf(ar_assign)) * (t > (ar_assign)),
         )
 
         first_lifetime_model_applied = get_conditional_lifetime_model(
@@ -469,8 +467,7 @@ class RenewalRewardProcess(RenewalProcess):
             lifetime_model_applied,
             lambda t: lifetime_model_applied.ls_integrate(
                 lambda x: (
-                    self.reward.conditional_expectation(x)
-                    * self.discounting.factor(x)
+                    self.reward.conditional_expectation(x) * self.discounting.factor(x)
                 ),
                 np.zeros_like(t),
                 np.asarray(t),
@@ -483,16 +480,14 @@ class RenewalRewardProcess(RenewalProcess):
             self.first_lifetime_model, a0=a0, ar=ar
         )
         delayed_evaluated_func = lambda t: first_lifetime_model_applied.ls_integrate(
-                lambda x: (
-                    self.first_reward.conditional_expectation(apply_bias(x,delay=a0))
-                    * self.discounting.factor(
-                        x
-                    )
-                ),
-                np.zeros_like(t),
-                np.asarray(t),
-                deg=15,
-            )
+            lambda x: (
+                self.first_reward.conditional_expectation(apply_bias(x, delay=a0))
+                * self.discounting.factor(x)
+            ),
+            np.zeros_like(t),
+            np.asarray(t),
+            deg=15,
+        )
 
         z = delayed_renewal_equation_solver(
             timeline,
@@ -553,8 +548,7 @@ class RenewalRewardProcess(RenewalProcess):
             return np.full_like(np.squeeze(lf), np.inf)
         ly = lifetime_model_applied.ls_integrate(
             lambda x: (
-                self.discounting.factor(x)
-                * self.reward.conditional_expectation(x)
+                self.discounting.factor(x) * self.reward.conditional_expectation(x)
             ),
             0.0,
             np.inf,
@@ -573,10 +567,8 @@ class RenewalRewardProcess(RenewalProcess):
         ly1 = np.squeeze(
             first_lifetime_model_applied.ls_integrate(
                 lambda x: (
-                    self.discounting.factor(
-                        x
-                    )
-                    * self.first_reward.conditional_expectation(apply_bias(x,delay=a0))
+                    self.discounting.factor(x)
+                    * self.first_reward.conditional_expectation(apply_bias(x, delay=a0))
                 ),
                 0.0,
                 np.inf,

--- a/src/relife/stochastic_process/renewal_process.py
+++ b/src/relife/stochastic_process/renewal_process.py
@@ -8,7 +8,9 @@ from numpy.typing import NDArray
 
 from relife.base import ParametricModel
 from relife.economic import ExponentialDiscounting, Reward
-from relife.lifetime_model._conditional_model import LeftTruncatedModel, get_conditional_lifetime_model
+from relife.lifetime_model._conditional_model import (
+    get_conditional_lifetime_model,
+)
 from relife.stochastic_process._sample import StochasticSampleMapping
 from relife.typing import AnyParametricLifetimeModel
 from relife.typing._scalars import AnyFloat, NumpyFloat
@@ -24,7 +26,12 @@ def _make_timeline(tf: float, nb_steps: int) -> NDArray[np.float64]:
     return np.atleast_2d(timeline)  # (1, nb_steps) to ensure broadcasting
 
 
-def apply_bias(t: AnyFloat, delay: NumpyFloat | None = None, censor_value: NumpyFloat | None = None, delay_applied_to_censor=False):
+def apply_bias(
+    t: AnyFloat,
+    delay: NumpyFloat | None = None,
+    censor_value: NumpyFloat | None = None,
+    delay_applied_to_censor=False,
+):
     if delay_applied_to_censor:
         return np.minimum(t, (censor_value or np.inf) - (delay or 0))
     return np.minimum(t + (delay or 0), (censor_value or np.inf))
@@ -35,7 +42,6 @@ class LifetimeFitArgs(TypedDict):
     event: NDArray[np.bool_]
     entry: NDArray[np.floating]
     args: tuple[NDArray[np.floating], ...]
-
 
 
 class RenewalProcess(ParametricModel):
@@ -78,7 +84,11 @@ class RenewalProcess(ParametricModel):
         self.first_lifetime_model = first_lifetime_model
 
     def renewal_function(
-        self, tf: float, nb_steps: int, a0: NumpyFloat | None = None, ar: NumpyFloat | None = None
+        self,
+        tf: float,
+        nb_steps: int,
+        a0: NumpyFloat | None = None,
+        ar: NumpyFloat | None = None,
     ) -> tuple[NDArray[np.float64], NDArray[np.float64]]:
         r"""The renewal function.
 
@@ -119,64 +129,87 @@ class RenewalProcess(ParametricModel):
 
         timeline = _make_timeline(tf, nb_steps)  # (nb_steps,) or (1, nb_steps)
         renewal_function = renewal_equation_solver(
-            timeline, get_conditional_lifetime_model(self.lifetime_model, ar=ar), get_conditional_lifetime_model(self.first_lifetime_model, ar=ar, a0=a0).cdf
+            timeline,
+            get_conditional_lifetime_model(self.lifetime_model, ar=ar),
+            get_conditional_lifetime_model(self.first_lifetime_model, ar=ar, a0=a0).cdf,
         )
         return np.squeeze(timeline), np.squeeze(renewal_function)
 
-    
     def expected_number_of_events(
-        self, tf: float, nb_steps: int, a0: NumpyFloat | None = None, ar: NumpyFloat | None = None
+        self,
+        tf: float,
+        nb_steps: int,
+        a0: NumpyFloat | None = None,
+        ar: NumpyFloat | None = None,
     ) -> tuple[NDArray[np.float64], NDArray[np.float64]]:
-        
+
         timeline = _make_timeline(tf, nb_steps)  # (nb_steps,) or (1, nb_steps)
 
-        lifetime_model_applied = get_conditional_lifetime_model(self.lifetime_model, ar=ar)
+        lifetime_model_applied = get_conditional_lifetime_model(
+            self.lifetime_model, ar=ar
+        )
         z = renewal_equation_solver(
             timeline,
             lifetime_model_applied,
-            lambda t: self.lifetime_model.cdf(apply_bias(t,censor_value=ar))
+            lambda t: self.lifetime_model.cdf(apply_bias(t, censor_value=ar)),
         )
 
-        first_lifetime_model_applied = get_conditional_lifetime_model(self.first_lifetime_model,a0=a0, ar=ar)
-        delayed_evaluated_func = lambda t: get_conditional_lifetime_model(self.first_lifetime_model,a0=a0).cdf(apply_bias(t,delay=a0,censor_value=ar,delay_applied_to_censor=True))
+        first_lifetime_model_applied = get_conditional_lifetime_model(
+            self.first_lifetime_model, a0=a0, ar=ar
+        )
+        delayed_evaluated_func = lambda t: get_conditional_lifetime_model(
+            self.first_lifetime_model, a0=a0
+        ).cdf(apply_bias(t, delay=a0, censor_value=ar, delay_applied_to_censor=True))
         z = delayed_renewal_equation_solver(
-            timeline,
-            z,
-            first_lifetime_model_applied,
-            delayed_evaluated_func
+            timeline, z, first_lifetime_model_applied, delayed_evaluated_func
         )
-        return np.squeeze(timeline), np.squeeze(
-            z
-        )
-    
+        return np.squeeze(timeline), np.squeeze(z)
+
     def expected_number_of_preventive_renewals(
-        self, tf: float, nb_steps: int, a0: NumpyFloat | None = None, ar: NumpyFloat | None = None
+        self,
+        tf: float,
+        nb_steps: int,
+        a0: NumpyFloat | None = None,
+        ar: NumpyFloat | None = None,
     ) -> tuple[NDArray[np.float64], NDArray[np.float64]]:
-        
+
         timeline = _make_timeline(tf, nb_steps)  # (nb_steps,) or (1, nb_steps)
 
-        lifetime_model_applied = get_conditional_lifetime_model(self.lifetime_model, ar=ar)
+        lifetime_model_applied = get_conditional_lifetime_model(
+            self.lifetime_model, ar=ar
+        )
         z = renewal_equation_solver(
             timeline,
             lifetime_model_applied,
-            lambda t: (1 - self.lifetime_model.cdf(ar or np.inf)) * (t > (ar or np.inf))
+            lambda t: (
+                (1 - self.lifetime_model.cdf(ar or np.inf)) * (t > (ar or np.inf))
+            ),
         )
 
-        first_lifetime_model_applied = get_conditional_lifetime_model(self.first_lifetime_model,a0=a0, ar=ar)
+        first_lifetime_model_applied = get_conditional_lifetime_model(
+            self.first_lifetime_model, a0=a0, ar=ar
+        )
         first_ar = (ar or np.inf) - (a0 or 0)
-        delayed_evaluated_func = lambda t: (1 - get_conditional_lifetime_model(self.first_lifetime_model, a0=a0).cdf(first_ar)) * (t > first_ar)
+        delayed_evaluated_func = lambda t: (
+            (
+                1
+                - get_conditional_lifetime_model(self.first_lifetime_model, a0=a0).cdf(
+                    first_ar
+                )
+            )
+            * (t > first_ar)
+        )
         z = delayed_renewal_equation_solver(
-            timeline,
-            z,
-            first_lifetime_model_applied,
-            delayed_evaluated_func
+            timeline, z, first_lifetime_model_applied, delayed_evaluated_func
         )
-        return np.squeeze(timeline), np.squeeze(
-            z
-        )
+        return np.squeeze(timeline), np.squeeze(z)
 
     def renewal_density(
-        self, tf: float, nb_steps: int, a0: NumpyFloat | None = None, ar: NumpyFloat | None = None
+        self,
+        tf: float,
+        nb_steps: int,
+        a0: NumpyFloat | None = None,
+        ar: NumpyFloat | None = None,
     ) -> tuple[NDArray[np.float64], NDArray[np.float64]]:
         r"""The renewal density.
 
@@ -216,7 +249,9 @@ class RenewalProcess(ParametricModel):
         """
         timeline = _make_timeline(tf, nb_steps)  #  (nb_steps,) or (m, nb_steps)
         renewal_density = renewal_equation_solver(
-            timeline, get_conditional_lifetime_model(self.lifetime_model, ar=ar), get_conditional_lifetime_model(self.first_lifetime_model, ar=ar, a0=a0).pdf
+            timeline,
+            get_conditional_lifetime_model(self.lifetime_model, ar=ar),
+            get_conditional_lifetime_model(self.first_lifetime_model, ar=ar, a0=a0).pdf,
         )
         return np.squeeze(timeline), np.squeeze(renewal_density)
 
@@ -378,7 +413,11 @@ class RenewalRewardProcess(RenewalProcess):
         self.discounting.rate = value
 
     def expected_total_reward(
-        self, tf: float, nb_steps: int, a0: NumpyFloat | None = None, ar: NumpyFloat | None = None
+        self,
+        tf: float,
+        nb_steps: int,
+        a0: NumpyFloat | None = None,
+        ar: NumpyFloat | None = None,
     ) -> tuple[NDArray[np.float64], NDArray[np.float64]]:
         r"""The expected total reward.
 
@@ -429,13 +468,16 @@ class RenewalRewardProcess(RenewalProcess):
         """
         timeline = _make_timeline(tf, nb_steps)  #  (nb_steps,) or (m, nb_steps)
 
-        lifetime_model_applied = get_conditional_lifetime_model(self.lifetime_model, ar=ar)
+        lifetime_model_applied = get_conditional_lifetime_model(
+            self.lifetime_model, ar=ar
+        )
         z = renewal_equation_solver(
             timeline,
             lifetime_model_applied,
             lambda t: self.lifetime_model.ls_integrate(
                 lambda x: (
-                    self.reward.conditional_expectation(x) * self.discounting.factor(apply_bias(x,censor_value=ar))
+                    self.reward.conditional_expectation(x)
+                    * self.discounting.factor(apply_bias(x, censor_value=ar))
                 ),
                 np.zeros_like(t),
                 np.asarray(t),
@@ -444,17 +486,27 @@ class RenewalRewardProcess(RenewalProcess):
             discounting=self.discounting,
         )
 
-
-        first_lifetime_model_applied = get_conditional_lifetime_model(self.first_lifetime_model,a0=a0, ar=ar)
-        delayed_evaluated_func = lambda t: get_conditional_lifetime_model(self.first_lifetime_model, a0=a0).ls_integrate(
+        first_lifetime_model_applied = get_conditional_lifetime_model(
+            self.first_lifetime_model, a0=a0, ar=ar
+        )
+        delayed_evaluated_func = (
+            lambda t: get_conditional_lifetime_model(
+                self.first_lifetime_model, a0=a0
+            ).ls_integrate(
                 lambda x: (
-                    self.first_reward.conditional_expectation(apply_bias(x,delay=a0)) * self.discounting.factor(apply_bias(x,censor_value=ar,delay=a0,delay_applied_to_censor=True))
+                    self.first_reward.conditional_expectation(apply_bias(x, delay=a0))
+                    * self.discounting.factor(
+                        apply_bias(
+                            x, censor_value=ar, delay=a0, delay_applied_to_censor=True
+                        )
+                    )
                 ),
                 np.zeros_like(t),
                 np.asarray(t),
                 deg=15,
-            ),  # reward partial expectation
-        
+            ),
+        )  # reward partial expectation
+
         z = delayed_renewal_equation_solver(
             timeline,
             z,
@@ -466,7 +518,9 @@ class RenewalRewardProcess(RenewalProcess):
             z
         )  # (nb_steps,), (nb_steps,) or (m, nb_steps)
 
-    def asymptotic_expected_total_reward(self, a0: NumpyFloat | None = None, ar: NumpyFloat | None = None) -> np.float64 | NDArray[np.float64]:
+    def asymptotic_expected_total_reward(
+        self, a0: NumpyFloat | None = None, ar: NumpyFloat | None = None
+    ) -> np.float64 | NDArray[np.float64]:
         r"""Asymptotic expected total reward.
 
         The asymptotic expected total reward is:
@@ -499,7 +553,9 @@ class RenewalRewardProcess(RenewalProcess):
             The assymptotic expected total reward of the process.
         """
 
-        lifetime_model_applied = get_conditional_lifetime_model(self.lifetime_model, ar=ar)
+        lifetime_model_applied = get_conditional_lifetime_model(
+            self.lifetime_model, ar=ar
+        )
         lf = lifetime_model_applied.ls_integrate(
             lambda x: self.discounting.factor(x),
             np.float64(0.0),
@@ -510,24 +566,33 @@ class RenewalRewardProcess(RenewalProcess):
             return np.full_like(np.squeeze(lf), np.inf)
         ly = self.lifetime_model.ls_integrate(
             lambda x: (
-                self.discounting.factor(apply_bias(x,censor_value=ar)) * self.reward.conditional_expectation(x)
+                self.discounting.factor(apply_bias(x, censor_value=ar))
+                * self.reward.conditional_expectation(x)
             ),
             0.0,
             np.inf,
             deg=100,
         )  # () or (m, 1)
         z = np.squeeze(ly / (1 - lf))  # () or (m,)
-        
-        first_lifetime_model_applied = get_conditional_lifetime_model(self.first_lifetime_model,a0=a0, ar=ar)
+
+        first_lifetime_model_applied = get_conditional_lifetime_model(
+            self.first_lifetime_model, a0=a0, ar=ar
+        )
         lf1 = np.squeeze(
-                first_lifetime_model_applied.ls_integrate(
+            first_lifetime_model_applied.ls_integrate(
                 lambda x: self.discounting.factor(x), 0.0, np.inf, deg=100
             )
         )  # () or (m,)
         ly1 = np.squeeze(
-                get_conditional_lifetime_model(self.first_lifetime_model,a0=a0).ls_integrate(
+            get_conditional_lifetime_model(
+                self.first_lifetime_model, a0=a0
+            ).ls_integrate(
                 lambda x: (
-                    self.discounting.factor(apply_bias(x,censor_value=ar,delay=a0,delay_applied_to_censor=True))
+                    self.discounting.factor(
+                        apply_bias(
+                            x, censor_value=ar, delay=a0, delay_applied_to_censor=True
+                        )
+                    )
                     * self.first_reward.conditional_expectation(x)
                 ),
                 0.0,
@@ -539,7 +604,11 @@ class RenewalRewardProcess(RenewalProcess):
         return z  # () or (m,)
 
     def expected_equivalent_annual_worth(
-        self, tf: float, nb_steps: int, a0 : NumpyFloat | None = None, ar: NumpyFloat | None = None
+        self,
+        tf: float,
+        nb_steps: int,
+        a0: NumpyFloat | None = None,
+        ar: NumpyFloat | None = None,
     ) -> tuple[NDArray[np.float64], NDArray[np.float64]]:
         """Expected equivalent annual worth.
 
@@ -580,7 +649,7 @@ class RenewalRewardProcess(RenewalProcess):
         )  # (nb_steps,) and (nb_steps) or (m, nb_steps)
 
     def asymptotic_expected_equivalent_annual_worth(
-        self, a0 : NumpyFloat | None = None, ar: NumpyFloat | None = None
+        self, a0: NumpyFloat | None = None, ar: NumpyFloat | None = None
     ) -> np.float64 | NDArray[np.float64]:
         """Asymptotic expected equivalent annual worth.
 
@@ -590,7 +659,9 @@ class RenewalRewardProcess(RenewalProcess):
             The assymptotic expected equivalent annual worth.
         """
 
-        lifetime_model_applied = get_conditional_lifetime_model(self.lifetime_model, ar=ar)
+        lifetime_model_applied = get_conditional_lifetime_model(
+            self.lifetime_model, ar=ar
+        )
         if self.discounting_rate == 0.0:
             return np.squeeze(
                 np.asarray(
@@ -604,6 +675,6 @@ class RenewalRewardProcess(RenewalProcess):
                 )
                 / lifetime_model_applied.mean()
             )  # () or (m,)
-        return (
-            self.discounting_rate * self.asymptotic_expected_total_reward(a0, ar)
+        return self.discounting_rate * self.asymptotic_expected_total_reward(
+            a0, ar
         )  # () or (m,)

--- a/src/relife/stochastic_process/renewal_process.py
+++ b/src/relife/stochastic_process/renewal_process.py
@@ -11,7 +11,7 @@ from relife.economic import ExponentialDiscounting, Reward
 from relife.lifetime_model._conditional_model import LeftTruncatedModel, get_conditional_lifetime_model
 from relife.stochastic_process._sample import StochasticSampleMapping
 from relife.typing import AnyParametricLifetimeModel
-from relife.typing._scalars import NumpyFloat
+from relife.typing._scalars import AnyFloat, NumpyFloat
 
 from ._renewal_equations import (
     delayed_renewal_equation_solver,
@@ -22,6 +22,12 @@ from ._renewal_equations import (
 def _make_timeline(tf: float, nb_steps: int) -> NDArray[np.float64]:
     timeline = np.linspace(0, tf, nb_steps, dtype=np.float64)  # (nb_steps,)
     return np.atleast_2d(timeline)  # (1, nb_steps) to ensure broadcasting
+
+
+def apply_bias(t: AnyFloat, delay: NumpyFloat | None = None, censor_value: NumpyFloat | None = None, delay_applied_to_censor=False):
+    if delay_applied_to_censor:
+        return np.minimum(t, (censor_value or np.inf) - (delay or 0))
+    return np.minimum(t + (delay or 0), (censor_value or np.inf))
 
 
 class LifetimeFitArgs(TypedDict):
@@ -128,12 +134,11 @@ class RenewalProcess(ParametricModel):
         z = renewal_equation_solver(
             timeline,
             lifetime_model_applied,
-            lambda t: self.lifetime_model.cdf(np.minimum(t, (ar or np.inf)))
+            lambda t: self.lifetime_model.cdf(apply_bias(t,censor_value=ar))
         )
 
         first_lifetime_model_applied = get_conditional_lifetime_model(self.first_lifetime_model,a0=a0, ar=ar)
-        first_ar = (ar or np.inf) - (a0 or 0)
-        delayed_evaluated_func = lambda t: get_conditional_lifetime_model(self.first_lifetime_model,a0=a0).cdf(np.minimum(t,first_ar))
+        delayed_evaluated_func = lambda t: get_conditional_lifetime_model(self.first_lifetime_model,a0=a0).cdf(apply_bias(t,delay=a0,censor_value=ar,delay_applied_to_censor=True))
         z = delayed_renewal_equation_solver(
             timeline,
             z,
@@ -430,7 +435,7 @@ class RenewalRewardProcess(RenewalProcess):
             lifetime_model_applied,
             lambda t: self.lifetime_model.ls_integrate(
                 lambda x: (
-                    self.reward.conditional_expectation(x) * self.discounting.factor(np.minimum(x,(ar or np.inf)))
+                    self.reward.conditional_expectation(x) * self.discounting.factor(apply_bias(x,censor_value=ar))
                 ),
                 np.zeros_like(t),
                 np.asarray(t),
@@ -443,7 +448,7 @@ class RenewalRewardProcess(RenewalProcess):
         first_lifetime_model_applied = get_conditional_lifetime_model(self.first_lifetime_model,a0=a0, ar=ar)
         delayed_evaluated_func = lambda t: get_conditional_lifetime_model(self.first_lifetime_model, a0=a0).ls_integrate(
                 lambda x: (
-                    self.first_reward.conditional_expectation(x) * self.discounting.factor(np.minimum(x,(ar or np.inf)))
+                    self.first_reward.conditional_expectation(apply_bias(x,delay=a0)) * self.discounting.factor(apply_bias(x,censor_value=ar,delay=a0,delay_applied_to_censor=True))
                 ),
                 np.zeros_like(t),
                 np.asarray(t),
@@ -505,7 +510,7 @@ class RenewalRewardProcess(RenewalProcess):
             return np.full_like(np.squeeze(lf), np.inf)
         ly = self.lifetime_model.ls_integrate(
             lambda x: (
-                self.discounting.factor(np.minimum(x,(ar or np.inf))) * self.reward.conditional_expectation(x)
+                self.discounting.factor(apply_bias(x,censor_value=ar)) * self.reward.conditional_expectation(x)
             ),
             0.0,
             np.inf,
@@ -519,11 +524,10 @@ class RenewalRewardProcess(RenewalProcess):
                 lambda x: self.discounting.factor(x), 0.0, np.inf, deg=100
             )
         )  # () or (m,)
-        first_ar = (ar or np.inf) - (a0 or 0)
         ly1 = np.squeeze(
                 get_conditional_lifetime_model(self.first_lifetime_model,a0=a0).ls_integrate(
                 lambda x: (
-                    self.discounting.factor(np.minimum(x,first_ar))
+                    self.discounting.factor(apply_bias(x,censor_value=ar,delay=a0,delay_applied_to_censor=True))
                     * self.first_reward.conditional_expectation(x)
                 ),
                 0.0,
@@ -564,6 +568,7 @@ class RenewalRewardProcess(RenewalProcess):
         if z.ndim == 2 and af.shape != z.shape:  # (m, nb_steps)
             af = np.tile(af, (z.shape[0], 1))  # (m, nb_steps)
         q = z / (af + 1e-6)  # # (nb_steps,) or (m, nb_steps) avoid zero division
+        # TODO : checker si c'est pas la pdf en 0 du first applied lifetime_model plutôt ici
         q0 = self.reward.conditional_expectation(
             np.asarray(0.0)
         ) * self.lifetime_model.pdf(0.0)

--- a/src/relife/stochastic_process/renewal_process.py
+++ b/src/relife/stochastic_process/renewal_process.py
@@ -128,7 +128,7 @@ class RenewalProcess(ParametricModel):
         z = renewal_equation_solver(
             timeline,
             lifetime_model_applied,
-            lambda t: self.lifetime_model.cdf(np.minimum(t, ar or np.inf))
+            lambda t: self.lifetime_model.cdf(np.minimum(t, (ar or np.inf)))
         )
 
         first_lifetime_model_applied = get_conditional_lifetime_model(self.first_lifetime_model,a0=a0, ar=ar)
@@ -430,7 +430,7 @@ class RenewalRewardProcess(RenewalProcess):
             lifetime_model_applied,
             lambda t: self.lifetime_model.ls_integrate(
                 lambda x: (
-                    self.reward.conditional_expectation(x) * self.discounting.factor(x)
+                    self.reward.conditional_expectation(x) * self.discounting.factor(np.minimum(x,(ar or np.inf)))
                 ),
                 np.zeros_like(t),
                 np.asarray(t),
@@ -443,7 +443,7 @@ class RenewalRewardProcess(RenewalProcess):
         first_lifetime_model_applied = get_conditional_lifetime_model(self.first_lifetime_model,a0=a0, ar=ar)
         delayed_evaluated_func = lambda t: get_conditional_lifetime_model(self.first_lifetime_model, a0=a0).ls_integrate(
                 lambda x: (
-                    self.first_reward.conditional_expectation(x + (a0 or 0)) * self.discounting.factor(x + (a0 or 0))
+                    self.first_reward.conditional_expectation(x) * self.discounting.factor(np.minimum(x,(ar or np.inf)))
                 ),
                 np.zeros_like(t),
                 np.asarray(t),
@@ -505,7 +505,7 @@ class RenewalRewardProcess(RenewalProcess):
             return np.full_like(np.squeeze(lf), np.inf)
         ly = self.lifetime_model.ls_integrate(
             lambda x: (
-                self.discounting.factor(x) * self.reward.conditional_expectation(x)
+                self.discounting.factor(np.minimum(x,(ar or np.inf))) * self.reward.conditional_expectation(x)
             ),
             0.0,
             np.inf,
@@ -519,11 +519,12 @@ class RenewalRewardProcess(RenewalProcess):
                 lambda x: self.discounting.factor(x), 0.0, np.inf, deg=100
             )
         )  # () or (m,)
+        first_ar = (ar or np.inf) - (a0 or 0)
         ly1 = np.squeeze(
                 get_conditional_lifetime_model(self.first_lifetime_model,a0=a0).ls_integrate(
                 lambda x: (
-                    self.discounting.factor(x + (a0 or 0))
-                    * self.first_reward.conditional_expectation(x + (a0 or 0))
+                    self.discounting.factor(np.minimum(x,first_ar))
+                    * self.first_reward.conditional_expectation(x)
                 ),
                 0.0,
                 np.inf,

--- a/src/relife/stochastic_process/renewal_process.py
+++ b/src/relife/stochastic_process/renewal_process.py
@@ -370,7 +370,6 @@ class RenewalRewardProcess(RenewalProcess):
 
         """
         timeline = _make_timeline(tf, nb_steps)  #  (nb_steps,) or (m, nb_steps)
-        # TODO: comprendre le delayed solver ici
         z = renewal_equation_solver(
             timeline,
             self.lifetime_model,

--- a/src/relife/stochastic_process/renewal_process.py
+++ b/src/relife/stochastic_process/renewal_process.py
@@ -479,8 +479,7 @@ class RenewalRewardProcess(RenewalProcess):
         first_lifetime_model_applied = get_conditional_lifetime_model(
             self.first_lifetime_model, a0=a0, ar=ar
         )
-        delayed_evaluated_func = (
-            lambda t: get_conditional_lifetime_model(
+        delayed_evaluated_func = lambda t: get_conditional_lifetime_model(
                 self.first_lifetime_model, a0=a0
             ).ls_integrate(
                 lambda x: (
@@ -494,8 +493,7 @@ class RenewalRewardProcess(RenewalProcess):
                 np.zeros_like(t),
                 np.asarray(t),
                 deg=15,
-            ),
-        )  # reward partial expectation
+            )
 
         z = delayed_renewal_equation_solver(
             timeline,

--- a/src/relife/stochastic_process/renewal_process.py
+++ b/src/relife/stochastic_process/renewal_process.py
@@ -13,8 +13,7 @@ from relife.lifetime_model._conditional_model import (
 )
 from relife.stochastic_process._sample import StochasticSampleMapping
 from relife.typing import AnyParametricLifetimeModel
-from relife.typing._scalars import AnyFloat, NumpyFloat
-
+from relife.typing._scalars import NumpyFloat
 from relife.utils.observation_bias import apply_bias
 
 from ._renewal_equations import (
@@ -630,7 +629,7 @@ class RenewalRewardProcess(RenewalProcess):
         q = z / (af + 1e-6)  # # (nb_steps,) or (m, nb_steps) avoid zero division
         q0 = self.reward.conditional_expectation(
             np.asarray(0.0)
-        ) * get_conditional_lifetime_model(self.lifetime_model,a0=a0).pdf(0.0)
+        ) * get_conditional_lifetime_model(self.lifetime_model, a0=a0).pdf(0.0)
         # q0 : () or (m, 1)
         q0 = np.broadcast_to(q0, af.shape)  # (), (nb_steps,) or (m, nb_steps)
         eeac = np.where(af == 0, q0, q)  # (nb_steps,) or (m, nb_steps)

--- a/src/relife/stochastic_process/renewal_process.py
+++ b/src/relife/stochastic_process/renewal_process.py
@@ -31,6 +31,7 @@ class LifetimeFitArgs(TypedDict):
     args: tuple[NDArray[np.floating], ...]
 
 
+
 class RenewalProcess(ParametricModel):
     # noinspection PyUnresolvedReferences
     """Renewal process.
@@ -115,6 +116,59 @@ class RenewalProcess(ParametricModel):
             timeline, get_conditional_lifetime_model(self.lifetime_model, ar=ar), get_conditional_lifetime_model(self.first_lifetime_model, ar=ar, a0=a0).cdf
         )
         return np.squeeze(timeline), np.squeeze(renewal_function)
+
+    
+    def expected_number_of_events(
+        self, tf: float, nb_steps: int, a0: NumpyFloat | None = None, ar: NumpyFloat | None = None
+    ) -> tuple[NDArray[np.float64], NDArray[np.float64]]:
+        
+        timeline = _make_timeline(tf, nb_steps)  # (nb_steps,) or (1, nb_steps)
+
+        lifetime_model_applied = get_conditional_lifetime_model(self.lifetime_model, ar=ar)
+        z = renewal_equation_solver(
+            timeline,
+            lifetime_model_applied,
+            lambda t: self.lifetime_model.cdf(np.minimum(t, ar or np.inf))
+        )
+
+        first_lifetime_model_applied = get_conditional_lifetime_model(self.first_lifetime_model,a0=a0, ar=ar)
+        first_ar = (ar or np.inf) - (a0 or 0)
+        delayed_evaluated_func = lambda t: get_conditional_lifetime_model(self.first_lifetime_model,a0=a0).cdf(np.minimum(t,first_ar))
+        z = delayed_renewal_equation_solver(
+            timeline,
+            z,
+            first_lifetime_model_applied,
+            delayed_evaluated_func
+        )
+        return np.squeeze(timeline), np.squeeze(
+            z
+        )
+    
+    def expected_number_of_preventive_renewals(
+        self, tf: float, nb_steps: int, a0: NumpyFloat | None = None, ar: NumpyFloat | None = None
+    ) -> tuple[NDArray[np.float64], NDArray[np.float64]]:
+        
+        timeline = _make_timeline(tf, nb_steps)  # (nb_steps,) or (1, nb_steps)
+
+        lifetime_model_applied = get_conditional_lifetime_model(self.lifetime_model, ar=ar)
+        z = renewal_equation_solver(
+            timeline,
+            lifetime_model_applied,
+            lambda t: (1 - self.lifetime_model.cdf(ar or np.inf)) * (t > (ar or np.inf))
+        )
+
+        first_lifetime_model_applied = get_conditional_lifetime_model(self.first_lifetime_model,a0=a0, ar=ar)
+        first_ar = (ar or np.inf) - (a0 or 0)
+        delayed_evaluated_func = lambda t: (1 - get_conditional_lifetime_model(self.first_lifetime_model, a0=a0).cdf(first_ar)) * (t > first_ar)
+        z = delayed_renewal_equation_solver(
+            timeline,
+            z,
+            first_lifetime_model_applied,
+            delayed_evaluated_func
+        )
+        return np.squeeze(timeline), np.squeeze(
+            z
+        )
 
     def renewal_density(
         self, tf: float, nb_steps: int, a0: NumpyFloat | None = None, ar: NumpyFloat | None = None

--- a/src/relife/stochastic_process/renewal_process.py
+++ b/src/relife/stochastic_process/renewal_process.py
@@ -1,7 +1,7 @@
 # pyright: basic
 
 import copy
-from typing import Any, TypedDict
+from typing import Any
 
 import numpy as np
 from numpy.typing import NDArray
@@ -14,27 +14,13 @@ from relife.lifetime_model._conditional_model import (
 from relife.stochastic_process._sample import StochasticSampleMapping
 from relife.typing import AnyParametricLifetimeModel
 from relife.typing._scalars import NumpyFloat
-from relife.utils._array_utils import reshape_1d_arg
+from relife.utils._array_utils import make_timeline
 from relife.utils.observation_bias import apply_bias, with_reshape_a0_ar
-
-import inspect
 
 from ._renewal_equations import (
     delayed_renewal_equation_solver,
     renewal_equation_solver,
 )
-
-
-def _make_timeline(tf: float, nb_steps: int) -> NDArray[np.float64]:
-    timeline = np.linspace(0, tf, nb_steps, dtype=np.float64)  # (nb_steps,)
-    return np.atleast_2d(timeline)  # (1, nb_steps) to ensure broadcasting
-
-
-class LifetimeFitArgs(TypedDict):
-    time: NDArray[np.floating]
-    event: NDArray[np.bool_]
-    entry: NDArray[np.floating]
-    args: tuple[NDArray[np.floating], ...]
 
 
 class RenewalProcess(ParametricModel):
@@ -47,7 +33,7 @@ class RenewalProcess(ParametricModel):
         A lifetime model representing the durations between events.
 
     first_lifetime_model : any lifetime distribution or frozen lifetime model, optional
-        A lifetime model for the first renewal (delayed renewal process). It is None by default
+        A lifetime model for the first renewal (delayed renewal process). It is lifetime_model by default.
 
     Attributes
     ----------
@@ -55,7 +41,7 @@ class RenewalProcess(ParametricModel):
         A lifetime model representing the durations between events.
 
     first_lifetime_model : any lifetime distribution or frozen lifetime model, optional
-        A lifetime model for the first renewal (delayed renewal process). It is None by default
+        A lifetime model for the first renewal (delayed renewal process). It is lifetime_model by default
     nb_params
     params
     params_names
@@ -108,6 +94,10 @@ class RenewalProcess(ParametricModel):
             The final time.
         nb_steps : int
             The number of steps used to discretized the time.
+        a0 : float or np.ndarray or None
+            Initial ages
+        ar : float or np.ndarray or None
+            Preventive ages of replacements
 
         Returns
         -------
@@ -121,7 +111,7 @@ class RenewalProcess(ParametricModel):
             Sons.
         """
 
-        timeline = _make_timeline(tf, nb_steps)  # (nb_steps,) or (1, nb_steps)
+        timeline = make_timeline(tf, nb_steps)  # (nb_steps,) or (1, nb_steps)
         renewal_function = renewal_equation_solver(
             timeline,
             get_conditional_lifetime_model(self.lifetime_model, ar=ar),
@@ -137,8 +127,26 @@ class RenewalProcess(ParametricModel):
         a0: NumpyFloat | None = None,
         ar: NumpyFloat | None = None,
     ) -> tuple[NDArray[np.float64], NDArray[np.float64]]:
+        r"""The expected number of events (no preventive renewals) at each time of the process.
 
-        timeline = _make_timeline(tf, nb_steps)  # (nb_steps,) or (1, nb_steps)
+        Parameters
+        ----------
+        tf : float
+            The final time.
+        nb_steps : int
+            The number of steps used to discretized the time.
+        a0 : float or np.ndarray or None
+            Initial ages
+        ar : float or np.ndarray or None
+            Preventive ages of replacements
+
+        Returns
+        -------
+        tuple of two ndarrays
+            A tuple containing the timeline and the computed values.
+        """
+
+        timeline = make_timeline(tf, nb_steps)  # (nb_steps,) or (1, nb_steps)
 
         lifetime_model_applied = get_conditional_lifetime_model(
             self.lifetime_model, ar=ar
@@ -149,6 +157,8 @@ class RenewalProcess(ParametricModel):
             lambda t: self.lifetime_model.cdf(apply_bias(t, censor_value=ar)),
         )
 
+        # Apply delay for the first renewal with a0
+        # If no a0 are given, will result in the same solution
         first_lifetime_model_applied = get_conditional_lifetime_model(
             self.first_lifetime_model, a0=a0, ar=ar
         )
@@ -168,11 +178,29 @@ class RenewalProcess(ParametricModel):
         a0: NumpyFloat | None = None,
         ar: NumpyFloat | None = None,
     ) -> tuple[NDArray[np.float64], NDArray[np.float64]]:
+        r"""The expected number of preventive renewals (no events) at each time of the process.
+
+        Parameters
+        ----------
+        tf : float
+            The final time.
+        nb_steps : int
+            The number of steps used to discretized the time.
+        a0 : float or np.ndarray or None
+            Initial ages
+        ar : float or np.ndarray or None
+            Preventive ages of replacements
+
+        Returns
+        -------
+        tuple of two ndarrays
+            A tuple containing the timeline and the computed values.
+        """
 
         ar_assign = ar if ar is not None else np.inf
         a0_assign = a0 if a0 is not None else 0
 
-        timeline = _make_timeline(tf, nb_steps)  # (nb_steps,) or (1, nb_steps)
+        timeline = make_timeline(tf, nb_steps)  # (nb_steps,) or (1, nb_steps)
 
         lifetime_model_applied = get_conditional_lifetime_model(
             self.lifetime_model, ar=ar
@@ -183,6 +211,8 @@ class RenewalProcess(ParametricModel):
             lambda t: (1 - self.lifetime_model.cdf(ar_assign)) * (t > (ar_assign)),
         )
 
+        # Apply delay for the first renewal with a0
+        # If no a0 are given, will result in the same solution
         first_lifetime_model_applied = get_conditional_lifetime_model(
             self.first_lifetime_model, a0=a0, ar=ar
         )
@@ -233,6 +263,10 @@ class RenewalProcess(ParametricModel):
             The final time.
         nb_steps : int
             The number of steps used to discretized the time.
+        a0 : float or np.ndarray or None
+            Initial ages
+        ar : float or np.ndarray or None
+            Preventive ages of replacements
 
         Returns
         -------
@@ -245,7 +279,7 @@ class RenewalProcess(ParametricModel):
             Theory: Models, Statistical Methods, and Applications. John Wiley &
             Sons.
         """
-        timeline = _make_timeline(tf, nb_steps)  #  (nb_steps,) or (m, nb_steps)
+        timeline = make_timeline(tf, nb_steps)  #  (nb_steps,) or (m, nb_steps)
         renewal_density = renewal_equation_solver(
             timeline,
             get_conditional_lifetime_model(self.lifetime_model, ar=ar),
@@ -272,6 +306,10 @@ class RenewalProcess(ParametricModel):
             The size of the desired sample
         time_window : tuple of two floats
             Time window in which data are sampled
+        a0 : float or np.ndarray or None
+            Initial ages
+        ar : float or np.ndarray or None
+            Preventive ages of replacements
         seed : int, optional
             Random seed, by default None.
 
@@ -309,6 +347,10 @@ class RenewalProcess(ParametricModel):
             The size of the desired sample
         time_window : tuple of two floats
             Time window in which data are sampled
+        a0 : float or np.ndarray or None
+            Initial ages
+        ar : float or np.ndarray or None
+            Preventive ages of replacements
         seed : int, optional
             Random seed, by default None.
 
@@ -362,7 +404,7 @@ class RenewalRewardProcess(RenewalProcess):
     discounting_rate : float
         The discounting rate value used in the exponential discounting function
     first_lifetime_model : any lifetime distribution or frozen lifetime model, optional
-        A lifetime model for the first renewal (delayed renewal process). It is None by default
+        A lifetime model for the first renewal (delayed renewal process). It is lifetime_model by default
     reward : Reward
         A reward object for the first renewal
 
@@ -371,7 +413,7 @@ class RenewalRewardProcess(RenewalProcess):
     lifetime_model : any lifetime distribution or frozen lifetime model
         A lifetime model representing the durations between events.
     first_lifetime_model : any lifetime distribution or frozen lifetime model, optional
-        A lifetime model for the first renewal (delayed renewal process). It is None by default
+        A lifetime model for the first renewal (delayed renewal process). It is lifetime_model by default
     reward : Reward
         A reward object that answers costs or conditional costs given lifetime values
     first_reward : Reward
@@ -460,6 +502,10 @@ class RenewalRewardProcess(RenewalProcess):
             The final time.
         nb_steps : int
             The number of steps used to discretized the time.
+        a0 : float or np.ndarray or None
+            Initial ages
+        ar : float or np.ndarray or None
+            Preventive ages of replacements
 
         Returns
         -------
@@ -467,7 +513,7 @@ class RenewalRewardProcess(RenewalProcess):
             A tuple containing the timeline and the computed values.
 
         """
-        timeline = _make_timeline(tf, nb_steps)  #  (nb_steps,) or (m, nb_steps)
+        timeline = make_timeline(tf, nb_steps)  #  (nb_steps,) or (m, nb_steps)
 
         lifetime_model_applied = get_conditional_lifetime_model(
             self.lifetime_model, ar=ar
@@ -486,6 +532,8 @@ class RenewalRewardProcess(RenewalProcess):
             discounting=self.discounting,
         )
 
+        # Apply delay for the first renewal with a0
+        # If no a0 are given, will result in the same solution
         first_lifetime_model_applied = get_conditional_lifetime_model(
             self.first_lifetime_model, a0=a0, ar=ar
         )
@@ -540,6 +588,13 @@ class RenewalRewardProcess(RenewalProcess):
         - :math:`X_1` the interarrival random variable of the first renewal.
         - :math:`Y_1` the associated reward of the first renewal.
 
+        Parameters
+        ----------
+        a0 : float or np.ndarray or None
+            Initial ages
+        ar : float or np.ndarray or None
+            Preventive ages of replacements
+
         Returns
         -------
         ndarray
@@ -567,6 +622,8 @@ class RenewalRewardProcess(RenewalProcess):
         )  # () or (m, 1)
         z = np.squeeze(ly / (1 - lf))  # () or (m,)
 
+        # Apply delay for the first renewal with a0
+        # If no a0 are given, will result in the same solution
         first_lifetime_model_applied = get_conditional_lifetime_model(
             self.first_lifetime_model, a0=a0, ar=ar
         )
@@ -611,6 +668,10 @@ class RenewalRewardProcess(RenewalProcess):
             The final time.
         nb_steps : int
             The number of steps used to discretized the time.
+        a0 : float or np.ndarray or None
+            Initial ages
+        ar : float or np.ndarray or None
+            Preventive ages of replacements
 
         Returns
         -------
@@ -639,6 +700,13 @@ class RenewalRewardProcess(RenewalProcess):
         self, a0: NumpyFloat | None = None, ar: NumpyFloat | None = None
     ) -> np.float64 | NDArray[np.float64]:
         """Asymptotic expected equivalent annual worth.
+
+        Parameters
+        ----------
+        a0 : float or np.ndarray or None
+            Initial ages
+        ar : float or np.ndarray or None
+            Preventive ages of replacements
 
         Returns
         -------

--- a/src/relife/stochastic_process/renewal_process.py
+++ b/src/relife/stochastic_process/renewal_process.py
@@ -15,6 +15,8 @@ from relife.stochastic_process._sample import StochasticSampleMapping
 from relife.typing import AnyParametricLifetimeModel
 from relife.typing._scalars import AnyFloat, NumpyFloat
 
+from relife.utils.observation_bias import apply_bias
+
 from ._renewal_equations import (
     delayed_renewal_equation_solver,
     renewal_equation_solver,
@@ -24,17 +26,6 @@ from ._renewal_equations import (
 def _make_timeline(tf: float, nb_steps: int) -> NDArray[np.float64]:
     timeline = np.linspace(0, tf, nb_steps, dtype=np.float64)  # (nb_steps,)
     return np.atleast_2d(timeline)  # (1, nb_steps) to ensure broadcasting
-
-
-def apply_bias(
-    t: AnyFloat,
-    delay: NumpyFloat | None = None,
-    censor_value: NumpyFloat | None = None,
-    delay_applied_to_censor=False,
-):
-    if delay_applied_to_censor:
-        return np.minimum(t, (censor_value or np.inf) - (delay or 0))
-    return np.minimum(t + (delay or 0), (censor_value or np.inf))
 
 
 class LifetimeFitArgs(TypedDict):
@@ -637,10 +628,9 @@ class RenewalRewardProcess(RenewalProcess):
         if z.ndim == 2 and af.shape != z.shape:  # (m, nb_steps)
             af = np.tile(af, (z.shape[0], 1))  # (m, nb_steps)
         q = z / (af + 1e-6)  # # (nb_steps,) or (m, nb_steps) avoid zero division
-        # TODO : checker si c'est pas la pdf en 0 du first applied lifetime_model plutôt ici
         q0 = self.reward.conditional_expectation(
             np.asarray(0.0)
-        ) * self.lifetime_model.pdf(0.0)
+        ) * get_conditional_lifetime_model(self.lifetime_model,a0=a0).pdf(0.0)
         # q0 : () or (m, 1)
         q0 = np.broadcast_to(q0, af.shape)  # (), (nb_steps,) or (m, nb_steps)
         eeac = np.where(af == 0, q0, q)  # (nb_steps,) or (m, nb_steps)

--- a/src/relife/stochastic_process/renewal_process.py
+++ b/src/relife/stochastic_process/renewal_process.py
@@ -8,6 +8,7 @@ from numpy.typing import NDArray
 
 from relife.base import ParametricModel
 from relife.economic import ExponentialDiscounting, Reward
+from relife.lifetime_model._conditional_model import LeftTruncatedModel, build_conditional_lifetime_model
 from relife.stochastic_process._sample import StochasticSampleMapping
 from relife.typing import AnyParametricLifetimeModel
 from relife.typing._scalars import NumpyFloat
@@ -70,7 +71,7 @@ class RenewalProcess(ParametricModel):
         self.first_lifetime_model = first_lifetime_model
 
     def renewal_function(
-        self, tf: float, nb_steps: int
+        self, tf: float, nb_steps: int, a0: NumpyFloat | None = None, ar: NumpyFloat | None = None
     ) -> tuple[NDArray[np.float64], NDArray[np.float64]]:
         r"""The renewal function.
 
@@ -111,12 +112,12 @@ class RenewalProcess(ParametricModel):
 
         timeline = _make_timeline(tf, nb_steps)  # (nb_steps,) or (1, nb_steps)
         renewal_function = renewal_equation_solver(
-            timeline, self.lifetime_model, self.first_lifetime_model.cdf
+            timeline, build_conditional_lifetime_model(self.lifetime_model, ar=ar), build_conditional_lifetime_model(self.first_lifetime_model, ar=ar, a0=a0).cdf
         )
         return np.squeeze(timeline), np.squeeze(renewal_function)
 
     def renewal_density(
-        self, tf: float, nb_steps: int
+        self, tf: float, nb_steps: int, a0: NumpyFloat | None = None, ar: NumpyFloat | None = None
     ) -> tuple[NDArray[np.float64], NDArray[np.float64]]:
         r"""The renewal density.
 
@@ -156,7 +157,7 @@ class RenewalProcess(ParametricModel):
         """
         timeline = _make_timeline(tf, nb_steps)  #  (nb_steps,) or (m, nb_steps)
         renewal_density = renewal_equation_solver(
-            timeline, self.lifetime_model, self.first_lifetime_model.pdf
+            timeline, build_conditional_lifetime_model(self.lifetime_model, ar=ar), build_conditional_lifetime_model(self.first_lifetime_model, ar=ar, a0=a0).pdf
         )
         return np.squeeze(timeline), np.squeeze(renewal_density)
 

--- a/src/relife/stochastic_process/renewal_process.py
+++ b/src/relife/stochastic_process/renewal_process.py
@@ -14,7 +14,10 @@ from relife.lifetime_model._conditional_model import (
 from relife.stochastic_process._sample import StochasticSampleMapping
 from relife.typing import AnyParametricLifetimeModel
 from relife.typing._scalars import NumpyFloat
-from relife.utils.observation_bias import apply_bias
+from relife.utils._array_utils import reshape_1d_arg
+from relife.utils.observation_bias import apply_bias, with_reshape_a0_ar
+
+import inspect
 
 from ._renewal_equations import (
     delayed_renewal_equation_solver,
@@ -73,6 +76,7 @@ class RenewalProcess(ParametricModel):
             first_lifetime_model = lifetime_model
         self.first_lifetime_model = first_lifetime_model
 
+    @with_reshape_a0_ar
     def renewal_function(
         self,
         tf: float,
@@ -125,6 +129,7 @@ class RenewalProcess(ParametricModel):
         )
         return np.squeeze(timeline), np.squeeze(renewal_function)
 
+    @with_reshape_a0_ar
     def expected_number_of_events(
         self,
         tf: float,
@@ -155,6 +160,7 @@ class RenewalProcess(ParametricModel):
         )
         return np.squeeze(timeline), np.squeeze(z)
 
+    @with_reshape_a0_ar
     def expected_number_of_preventive_renewals(
         self,
         tf: float,
@@ -195,6 +201,7 @@ class RenewalProcess(ParametricModel):
         )
         return np.squeeze(timeline), np.squeeze(z)
 
+    @with_reshape_a0_ar
     def renewal_density(
         self,
         tf: float,
@@ -246,6 +253,7 @@ class RenewalProcess(ParametricModel):
         )
         return np.squeeze(timeline), np.squeeze(renewal_density)
 
+    @with_reshape_a0_ar
     def sample(
         self,
         nb_samples: int,
@@ -282,6 +290,7 @@ class RenewalProcess(ParametricModel):
             struct_array, iterable.nb_assets, nb_samples
         )
 
+    @with_reshape_a0_ar
     def generate_failure_data(
         self,
         nb_samples: int,
@@ -403,6 +412,7 @@ class RenewalRewardProcess(RenewalProcess):
     def discounting_rate(self, value: float) -> None:
         self.discounting.rate = value
 
+    @with_reshape_a0_ar
     def expected_total_reward(
         self,
         tf: float,
@@ -500,6 +510,7 @@ class RenewalRewardProcess(RenewalProcess):
             z
         )  # (nb_steps,), (nb_steps,) or (m, nb_steps)
 
+    @with_reshape_a0_ar
     def asymptotic_expected_total_reward(
         self, a0: NumpyFloat | None = None, ar: NumpyFloat | None = None
     ) -> np.float64 | NDArray[np.float64]:
@@ -578,6 +589,7 @@ class RenewalRewardProcess(RenewalProcess):
         z = ly1 + z * lf1  # () or (m,)
         return z  # () or (m,)
 
+    @with_reshape_a0_ar
     def expected_equivalent_annual_worth(
         self,
         tf: float,
@@ -622,6 +634,7 @@ class RenewalRewardProcess(RenewalProcess):
             eeac
         )  # (nb_steps,) and (nb_steps) or (m, nb_steps)
 
+    @with_reshape_a0_ar
     def asymptotic_expected_equivalent_annual_worth(
         self, a0: NumpyFloat | None = None, ar: NumpyFloat | None = None
     ) -> np.float64 | NDArray[np.float64]:

--- a/src/relife/stochastic_process/renewal_process.py
+++ b/src/relife/stochastic_process/renewal_process.py
@@ -8,7 +8,7 @@ from numpy.typing import NDArray
 
 from relife.base import ParametricModel
 from relife.economic import ExponentialDiscounting, Reward
-from relife.lifetime_model._conditional_model import LeftTruncatedModel, build_conditional_lifetime_model
+from relife.lifetime_model._conditional_model import LeftTruncatedModel, get_conditional_lifetime_model
 from relife.stochastic_process._sample import StochasticSampleMapping
 from relife.typing import AnyParametricLifetimeModel
 from relife.typing._scalars import NumpyFloat
@@ -112,7 +112,7 @@ class RenewalProcess(ParametricModel):
 
         timeline = _make_timeline(tf, nb_steps)  # (nb_steps,) or (1, nb_steps)
         renewal_function = renewal_equation_solver(
-            timeline, build_conditional_lifetime_model(self.lifetime_model, ar=ar), build_conditional_lifetime_model(self.first_lifetime_model, ar=ar, a0=a0).cdf
+            timeline, get_conditional_lifetime_model(self.lifetime_model, ar=ar), get_conditional_lifetime_model(self.first_lifetime_model, ar=ar, a0=a0).cdf
         )
         return np.squeeze(timeline), np.squeeze(renewal_function)
 
@@ -157,7 +157,7 @@ class RenewalProcess(ParametricModel):
         """
         timeline = _make_timeline(tf, nb_steps)  #  (nb_steps,) or (m, nb_steps)
         renewal_density = renewal_equation_solver(
-            timeline, build_conditional_lifetime_model(self.lifetime_model, ar=ar), build_conditional_lifetime_model(self.first_lifetime_model, ar=ar, a0=a0).pdf
+            timeline, get_conditional_lifetime_model(self.lifetime_model, ar=ar), get_conditional_lifetime_model(self.first_lifetime_model, ar=ar, a0=a0).pdf
         )
         return np.squeeze(timeline), np.squeeze(renewal_density)
 
@@ -288,8 +288,6 @@ class RenewalRewardProcess(RenewalProcess):
     params_names
     """
 
-    lifetime_model: AnyParametricLifetimeModel[()]
-    first_lifetime_model: AnyParametricLifetimeModel[()]
     reward: Reward
     first_reward: Reward
     discounting: ExponentialDiscounting
@@ -321,7 +319,7 @@ class RenewalRewardProcess(RenewalProcess):
         self.discounting.rate = value
 
     def expected_total_reward(
-        self, tf: float, nb_steps: int
+        self, tf: float, nb_steps: int, a0: NumpyFloat | None = None, ar: NumpyFloat | None = None
     ) -> tuple[NDArray[np.float64], NDArray[np.float64]]:
         r"""The expected total reward.
 
@@ -371,10 +369,12 @@ class RenewalRewardProcess(RenewalProcess):
 
         """
         timeline = _make_timeline(tf, nb_steps)  #  (nb_steps,) or (m, nb_steps)
+
+        lifetime_model_applied = get_conditional_lifetime_model(self.lifetime_model, ar=ar)
         z = renewal_equation_solver(
             timeline,
-            self.lifetime_model,
-            lambda t: self.lifetime_model.ls_integrate(
+            lifetime_model_applied,
+            lambda t: lifetime_model_applied.ls_integrate(
                 lambda x: (
                     self.reward.conditional_expectation(x) * self.discounting.factor(x)
                 ),
@@ -384,11 +384,13 @@ class RenewalRewardProcess(RenewalProcess):
             ),  # reward partial expectation
             discounting=self.discounting,
         )
+
+        first_lifetime_model_applied = get_conditional_lifetime_model(self.first_lifetime_model,a0=a0, ar=ar)
         z = delayed_renewal_equation_solver(
             timeline,
             z,
-            self.first_lifetime_model,
-            lambda t: self.first_lifetime_model.ls_integrate(
+            first_lifetime_model_applied,
+            lambda t: first_lifetime_model_applied.ls_integrate(
                 lambda x: (
                     self.first_reward.conditional_expectation(x)
                     * self.discounting.factor(x)
@@ -403,7 +405,7 @@ class RenewalRewardProcess(RenewalProcess):
             z
         )  # (nb_steps,), (nb_steps,) or (m, nb_steps)
 
-    def asymptotic_expected_total_reward(self) -> np.float64 | NDArray[np.float64]:
+    def asymptotic_expected_total_reward(self, a0: NumpyFloat | None = None, ar: NumpyFloat | None = None) -> np.float64 | NDArray[np.float64]:
         r"""Asymptotic expected total reward.
 
         The asymptotic expected total reward is:
@@ -435,7 +437,9 @@ class RenewalRewardProcess(RenewalProcess):
         ndarray
             The assymptotic expected total reward of the process.
         """
-        lf = self.lifetime_model.ls_integrate(
+
+        lifetime_model_applied = get_conditional_lifetime_model(self.lifetime_model, ar=ar)
+        lf = lifetime_model_applied.ls_integrate(
             lambda x: self.discounting.factor(x),
             np.float64(0.0),
             np.asarray(np.inf),
@@ -443,7 +447,7 @@ class RenewalRewardProcess(RenewalProcess):
         )  # () or (m, 1)
         if self.discounting_rate == 0.0:
             return np.full_like(np.squeeze(lf), np.inf)
-        ly = self.lifetime_model.ls_integrate(
+        ly = lifetime_model_applied.ls_integrate(
             lambda x: (
                 self.discounting.factor(x) * self.reward.conditional_expectation(x)
             ),
@@ -452,14 +456,15 @@ class RenewalRewardProcess(RenewalProcess):
             deg=100,
         )  # () or (m, 1)
         z = np.squeeze(ly / (1 - lf))  # () or (m,)
-
+        
+        first_lifetime_model_applied = get_conditional_lifetime_model(self.first_lifetime_model,a0=a0, ar=ar)
         lf1 = np.squeeze(
-            self.first_lifetime_model.ls_integrate(
+                first_lifetime_model_applied.ls_integrate(
                 lambda x: self.discounting.factor(x), 0.0, np.inf, deg=100
             )
         )  # () or (m,)
         ly1 = np.squeeze(
-            self.first_lifetime_model.ls_integrate(
+                first_lifetime_model_applied.ls_integrate(
                 lambda x: (
                     self.discounting.factor(x)
                     * self.first_reward.conditional_expectation(x)
@@ -473,7 +478,7 @@ class RenewalRewardProcess(RenewalProcess):
         return z  # () or (m,)
 
     def expected_equivalent_annual_worth(
-        self, tf: float, nb_steps: int
+        self, tf: float, nb_steps: int, a0 : NumpyFloat | None = None, ar: NumpyFloat | None = None
     ) -> tuple[NDArray[np.float64], NDArray[np.float64]]:
         """Expected equivalent annual worth.
 
@@ -496,7 +501,7 @@ class RenewalRewardProcess(RenewalProcess):
             A tuple containing the timeline and the computed values.
         """
         timeline, z = self.expected_total_reward(
-            tf, nb_steps
+            tf, nb_steps, a0=a0, ar=ar
         )  # timeline : (nb_steps,) z : (nb_steps,) or (m, nb_steps)
         af = self.discounting.annuity_factor(timeline)  # (nb_steps,)
         if z.ndim == 2 and af.shape != z.shape:  # (m, nb_steps)
@@ -513,7 +518,7 @@ class RenewalRewardProcess(RenewalProcess):
         )  # (nb_steps,) and (nb_steps) or (m, nb_steps)
 
     def asymptotic_expected_equivalent_annual_worth(
-        self,
+        self, a0 : NumpyFloat | None = None, ar: NumpyFloat | None = None
     ) -> np.float64 | NDArray[np.float64]:
         """Asymptotic expected equivalent annual worth.
 
@@ -522,10 +527,12 @@ class RenewalRewardProcess(RenewalProcess):
         ndarray
             The assymptotic expected equivalent annual worth.
         """
+
+        lifetime_model_applied = get_conditional_lifetime_model(self.lifetime_model, ar=ar)
         if self.discounting_rate == 0.0:
             return np.squeeze(
                 np.asarray(
-                    self.lifetime_model.ls_integrate(
+                    lifetime_model_applied.ls_integrate(
                         lambda x: self.reward.conditional_expectation(x),
                         np.float64(0.0),
                         np.asarray(np.inf),
@@ -533,8 +540,8 @@ class RenewalRewardProcess(RenewalProcess):
                     ),
                     dtype=float,
                 )
-                / self.lifetime_model.mean()
+                / lifetime_model_applied.mean()
             )  # () or (m,)
         return (
-            self.discounting_rate * self.asymptotic_expected_total_reward()
+            self.discounting_rate * self.asymptotic_expected_total_reward(a0, ar)
         )  # () or (m,)

--- a/src/relife/stochastic_process/renewal_process.py
+++ b/src/relife/stochastic_process/renewal_process.py
@@ -59,7 +59,7 @@ class RenewalProcess(ParametricModel):
     """
 
     lifetime_model: AnyParametricLifetimeModel[()]
-    first_lifetime_model: AnyParametricLifetimeModel[()] | None
+    first_lifetime_model: AnyParametricLifetimeModel[()]
 
     def __init__(
         self,
@@ -68,6 +68,9 @@ class RenewalProcess(ParametricModel):
     ) -> None:
         super().__init__()
         self.lifetime_model = lifetime_model
+        if first_lifetime_model is None:
+            # TODO: use copy method
+            first_lifetime_model = lifetime_model
         self.first_lifetime_model = first_lifetime_model
 
     def renewal_function(
@@ -114,9 +117,7 @@ class RenewalProcess(ParametricModel):
         renewal_function = renewal_equation_solver(
             timeline,
             self.lifetime_model,
-            self.lifetime_model.cdf
-            if self.first_lifetime_model is None
-            else self.first_lifetime_model.cdf,
+            self.first_lifetime_model.cdf
         )
         return np.squeeze(timeline), np.squeeze(renewal_function)
 
@@ -163,9 +164,7 @@ class RenewalProcess(ParametricModel):
         renewal_density = renewal_equation_solver(
             timeline,
             self.lifetime_model,
-            self.lifetime_model.pdf
-            if self.first_lifetime_model is None
-            else self.first_lifetime_model.pdf,
+            self.first_lifetime_model.pdf
         )
         return np.squeeze(timeline), np.squeeze(renewal_density)
 
@@ -236,22 +235,11 @@ class RenewalProcess(ParametricModel):
         from ._sample import RenewalProcessIterable
 
         if (
-            self.first_lifetime_model is not None
-            and self.first_lifetime_model != self.lifetime_model
+            self.first_lifetime_model != self.lifetime_model
         ):
-            if isinstance(self.first_lifetime_model, FrozenParametricModel):
-                if (
-                    isinstance(
-                        self.first_lifetime_model._unfrozen_model, LeftTruncatedModel
-                    )
-                    and self.first_lifetime_model._unfrozen_model.baseline
-                    == self.lifetime_model
-                ):
-                    pass
-            else:
-                raise ValueError(
-                    "Calling sample_lifetime_data with lifetime_model different from first_lifetime_model is ambiguous."
-                )
+            raise ValueError(
+                "Calling sample_lifetime_data with lifetime_model different from first_lifetime_model is ambiguous."
+            )
         iterable = RenewalProcessIterable(
             self, nb_samples, time_window, a0=a0, ar=ar, seed=seed
         )
@@ -311,7 +299,7 @@ class RenewalRewardProcess(RenewalProcess):
     """
 
     lifetime_model: AnyParametricLifetimeModel[()]
-    first_lifetime_model: AnyParametricLifetimeModel[()] | None
+    first_lifetime_model: AnyParametricLifetimeModel[()]
     reward: Reward
     first_reward: Reward
     discounting: ExponentialDiscounting
@@ -393,10 +381,11 @@ class RenewalRewardProcess(RenewalProcess):
 
         """
         timeline = _make_timeline(tf, nb_steps)  #  (nb_steps,) or (m, nb_steps)
+        # TODO: comprendre le delayed solver ici
         z = renewal_equation_solver(
             timeline,
-            self.lifetime_model,
-            lambda t: self.lifetime_model.ls_integrate(
+            self.first_lifetime_model,
+            lambda t: self.first_lifetime_model.ls_integrate(
                 lambda x: (
                     self.reward.conditional_expectation(x) * self.discounting.factor(x)
                 ),
@@ -475,24 +464,24 @@ class RenewalRewardProcess(RenewalProcess):
             deg=100,
         )  # () or (m, 1)
         z = np.squeeze(ly / (1 - lf))  # () or (m,)
-        if self.first_lifetime_model is not None:
-            lf1 = np.squeeze(
-                self.first_lifetime_model.ls_integrate(
-                    lambda x: self.discounting.factor(x), 0.0, np.inf, deg=100
-                )
-            )  # () or (m,)
-            ly1 = np.squeeze(
-                self.first_lifetime_model.ls_integrate(
-                    lambda x: (
-                        self.discounting.factor(x)
-                        * self.first_reward.conditional_expectation(x)
-                    ),
-                    0.0,
-                    np.inf,
-                    deg=100,
-                )
-            )  # () or (m,)
-            z = ly1 + z * lf1  # () or (m,)
+
+        lf1 = np.squeeze(
+            self.first_lifetime_model.ls_integrate(
+                lambda x: self.discounting.factor(x), 0.0, np.inf, deg=100
+            )
+        )  # () or (m,)
+        ly1 = np.squeeze(
+            self.first_lifetime_model.ls_integrate(
+                lambda x: (
+                    self.discounting.factor(x)
+                    * self.first_reward.conditional_expectation(x)
+                ),
+                0.0,
+                np.inf,
+                deg=100,
+            )
+        )  # () or (m,)
+        z = ly1 + z * lf1  # () or (m,)
         return z  # () or (m,)
 
     def expected_equivalent_annual_worth(
@@ -525,14 +514,9 @@ class RenewalRewardProcess(RenewalProcess):
         if z.ndim == 2 and af.shape != z.shape:  # (m, nb_steps)
             af = np.tile(af, (z.shape[0], 1))  # (m, nb_steps)
         q = z / (af + 1e-6)  # # (nb_steps,) or (m, nb_steps) avoid zero division
-        if self.first_lifetime_model is not None:
-            q0 = self.first_reward.conditional_expectation(
-                np.asarray(0.0)
-            ) * self.first_lifetime_model.pdf(0.0)
-        else:
-            q0 = self.reward.conditional_expectation(
-                np.asarray(0.0)
-            ) * self.lifetime_model.pdf(0.0)
+        q0 = self.reward.conditional_expectation(
+            np.asarray(0.0)
+        ) * self.lifetime_model.pdf(0.0)
         # q0 : () or (m, 1)
         q0 = np.broadcast_to(q0, af.shape)  # (), (nb_steps,) or (m, nb_steps)
         eeac = np.where(af == 0, q0, q)  # (nb_steps,) or (m, nb_steps)

--- a/src/relife/utils/_array_utils.py
+++ b/src/relife/utils/_array_utils.py
@@ -81,3 +81,8 @@ def get_args_nb_assets(*args: NDArray[Any]) -> int:
     if len(broadcast_shape) == 0:
         return 1
     return broadcast_shape[0]
+
+
+def make_timeline(tf: float, nb_steps: int) -> NDArray[np.float64]:
+    timeline = np.linspace(0, tf, nb_steps, dtype=np.float64)  # (nb_steps,)
+    return np.atleast_2d(timeline)  # (1, nb_steps) to ensure broadcasting

--- a/src/relife/utils/_model_checks.py
+++ b/src/relife/utils/_model_checks.py
@@ -28,12 +28,10 @@ def get_model_nb_assets(model):
 
     if isinstance(model, RenewalProcess):
         lifetime_model_nb_assets = get_model_nb_assets(model.lifetime_model)
-        if model.first_lifetime_model is not None:
-            first_lifetime_model_nb_assets = get_model_nb_assets(
+        first_lifetime_model_nb_assets = get_model_nb_assets(
                 model.first_lifetime_model
             )
-            return max(lifetime_model_nb_assets, first_lifetime_model_nb_assets)
-        return lifetime_model_nb_assets
+        return max(lifetime_model_nb_assets, first_lifetime_model_nb_assets)
 
     if isinstance(model, FrozenParametricModel):
         if isinstance(model._unfrozen_model, NonHomogeneousPoissonProcess):

--- a/src/relife/utils/observation_bias.py
+++ b/src/relife/utils/observation_bias.py
@@ -1,0 +1,14 @@
+import numpy as np
+
+from relife.typing._scalars import AnyFloat, NumpyFloat
+
+
+def apply_bias(
+    t: AnyFloat,
+    delay: NumpyFloat | None = None,
+    censor_value: NumpyFloat | None = None,
+    delay_applied_to_censor=False,
+):
+    if delay_applied_to_censor:
+        return np.minimum(t, (censor_value or np.inf) - (delay or 0))
+    return np.minimum(t + (delay or 0), (censor_value or np.inf))

--- a/src/relife/utils/observation_bias.py
+++ b/src/relife/utils/observation_bias.py
@@ -16,3 +16,20 @@ def apply_bias(
     if delay_applied_to_censor:
         return np.minimum(t, censor_value - delay)
     return np.minimum(t + delay,censor_value)
+
+
+
+def with_reshape_a0_ar(func):
+    sig = inspect.signature(func)
+    params = sig.parameters
+
+    def wrapper(*args, **kwargs):
+        if "a0" in params and kwargs.get("a0") is not None:
+            kwargs["a0"] = reshape_1d_arg(kwargs["a0"])
+
+        if "ar" in params and kwargs.get("ar") is not None:
+            kwargs["ar"] = reshape_1d_arg(kwargs["ar"])
+
+        return func(*args, **kwargs)
+
+    return wrapper

--- a/src/relife/utils/observation_bias.py
+++ b/src/relife/utils/observation_bias.py
@@ -1,6 +1,9 @@
+import inspect
+
 import numpy as np
 
 from relife.typing._scalars import AnyFloat, NumpyFloat
+from relife.utils._array_utils import reshape_1d_arg
 
 
 def apply_bias(

--- a/src/relife/utils/observation_bias.py
+++ b/src/relife/utils/observation_bias.py
@@ -9,6 +9,10 @@ def apply_bias(
     censor_value: NumpyFloat | None = None,
     delay_applied_to_censor=False,
 ):
+    if censor_value is None:
+        censor_value = np.inf
+    if delay is None:
+        delay = 0
     if delay_applied_to_censor:
-        return np.minimum(t, (censor_value or np.inf) - (delay or 0))
-    return np.minimum(t + (delay or 0), (censor_value or np.inf))
+        return np.minimum(t, censor_value - delay)
+    return np.minimum(t + delay,censor_value)


### PR DESCRIPTION
**1. API changes :**

The main objective is to change the usage of `LeftTruncatedModel` and `AgeReplacementModel` to be used only as "in place decorators" for lifetime models.
Schematically, an `AgeReplacementModel` censors the survival function at **ar** but does not make anything else. It has no knowledge of events or entry values, as it did before in the `rvs` method.

Concerning user API, the idea is that these models shouldn't be used by users, they are only used inside other methods for relife to help computations.

I see that this change implies modifications in three main modules of relife : **rvs of lifeitme models**, **stochastic processes** and **policies**

_In RVS :_ 

The `rvs` method doesn't retun event and entries as it did before. Only time values (that are equivalent to residual time if the model was left truncated).

It simplifies the signature and the content of the `rvs` method. It also limits the error cases with critical usage of interlocked models.

_In Stochastic Processes :_

It is no longer the responsibility of the user to make Left Truncated or Age Replacement Model before initiating a Renewal Process or a NHPP.

Now, only the full lifetime distribution are used when defining a stochastic process (which makes more sense mathematically and is lighter in terms of code).

The methods of sampling or renewal functions now have optional **a0** and **ar** arguments to make the computations associated with observation bias if necessary. These computations are carried out automatically by relife instead of relying on the user understanding.

For Renewal Process specifically, it implies a change for the first lifetime model. Now, the only reason to make a different model for the first is if the inner lifetime distribution is different. If it is the same law but only lefttruncated, we don't need to init a different lifetime model !

_In Policies :_

Changes in policies directly follow the changes of renewal process. The `Reward` objects are redefined to be used with optional **a0** and **ar** arguments, and carries the modifications associated with observation bias internally.


**2. Utils method changes :**

I added methods to helpthe build of conditional models or the modifications of time values in cases of observation bias. 

`get_conditional_lifetime_model` : Build the conditional model using optional **a0** and **ar** arguments. Left truncation is applied before for numerical stability (even if the code is a bit longer this way)

`apply_bias` : Apply bias to time values. Useful to get the complete times by adding the initial age to the residual time for example.

`with_reshape_a0_ar` : decorator useful for all methods that takes a0 and ar as optional arguments, to make the correct reshaping before entering computations

`check_impossible_replacements` : decorator used in policies, to detect when optimal replacement are not possible because initial ages are too high. Used to avoid code duplications.

**3. Test changes :**

All tests are changed to align with new usage of **a0** and **ar**. Doesn't really involve adding anything, rather simplifications.

I haven't checked if some pytest fixtures could be removed with these simplifications.